### PR TITLE
feat: add legacy event json files

### DIFF
--- a/legacy_event_data/firebase-auth1.json
+++ b/legacy_event_data/firebase-auth1.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "email": "test@nowhere.com",
+    "metadata": {
+      "createdAt": "2020-05-26T10:42:27Z"
+    },
+    "providerData": [
+      {
+        "email": "test@nowhere.com",
+        "providerId": "password",
+        "uid": "test@nowhere.com"
+      }
+    ],
+    "uid": "UUpby3s4spZre6kHsgVSPetzQ8l2"
+  },
+  "eventId": "4423b4fa-c39b-4f79-b338-977a018e9b55",
+  "eventType": "providers/firebase.auth/eventTypes/user.create",
+  "notSupported": {
+  },
+  "resource": "projects/my-project-id",
+  "timestamp": "2020-05-26T10:42:27.088Z"
+}

--- a/legacy_event_data/firebase-auth2.json
+++ b/legacy_event_data/firebase-auth2.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "email": "test@nowhere.com",
+    "metadata": {
+      "createdAt": "2020-05-26T10:42:27Z"
+    },
+    "providerData": [
+      {
+        "email": "test@nowhere.com",
+        "providerId": "password",
+        "uid": "test@nowhere.com"
+      }
+    ],
+    "uid": "UUpby3s4spZre6kHsgVSPetzQ8l2"
+  },
+  "eventId": "5fd71bdc-4955-421f-9fc3-552ac3abead8",
+  "eventType": "providers/firebase.auth/eventTypes/user.delete",
+  "notSupported": {
+  },
+  "resource": "projects/my-project-id",
+  "timestamp": "2020-05-26T10:47:14.205Z"
+}

--- a/legacy_event_data/firebase-db1.json
+++ b/legacy_event_data/firebase-db1.json
@@ -1,0 +1,18 @@
+{
+  "eventType": "providers/google.firebase.database/eventTypes/ref.write",
+  "params": {
+    "child": "xyz"
+  },
+  "auth": {
+    "admin": true
+  },
+  "data": {
+    "data": null,
+    "delta": {
+      "grandchild": "other"
+    }
+  },
+  "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+  "timestamp": "2020-05-21T11:15:34.178Z",
+  "eventId": "/SnHth9OSlzK1Puj85kk4tDbF90="
+}

--- a/legacy_event_data/firebase-db2.json
+++ b/legacy_event_data/firebase-db2.json
@@ -1,0 +1,20 @@
+{
+  "eventType": "providers/google.firebase.database/eventTypes/ref.write",
+  "params": {
+    "child": "xyz"
+  },
+  "auth": {
+    "admin": true
+  },
+  "data": {
+    "data": {
+      "grandchild": "other"
+    },
+    "delta": {
+      "grandchild": "other changed"
+    }
+  },
+  "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+  "timestamp": "2020-05-21T11:17:09.217Z",
+  "eventId": "xaU5mk9HaahKU/T/XlPo/1ansu8="
+}

--- a/legacy_event_data/firebase-db3.json
+++ b/legacy_event_data/firebase-db3.json
@@ -1,0 +1,16 @@
+{
+  "eventType": "providers/google.firebase.database/eventTypes/ref.write",
+  "params": {
+    "child": "abc"
+  },
+  "auth": {
+    "admin": true
+  },
+  "data": {
+    "data": null,
+    "delta": 10
+  },
+  "resource": "projects/_/instances/my-project-id/refs/gcf-test/abc",
+  "timestamp": "2020-05-21T11:17:17.809Z",
+  "eventId": "kbAmkXNSQhmARA0JB5lcCt1Zpsg="
+}

--- a/legacy_event_data/firebase-db4.json
+++ b/legacy_event_data/firebase-db4.json
@@ -1,0 +1,25 @@
+{
+  "eventType": "providers/google.firebase.database/eventTypes/ref.write",
+  "params": {
+    "child": "xyz"
+  },
+  "auth": {
+    "admin": true
+  },
+  "data": {
+    "data": {
+      "grandchild": "other changed"
+    },
+    "delta": {
+      "deeply": {
+        "nested": {
+          "text": "This is deeply nested",
+          "text2": "Second value"
+        }
+      }
+    }
+  },
+  "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+  "timestamp": "2020-05-21T11:19:22.677Z",
+  "eventId": "AlEKy6dsGnn48ubD7Y5QOoROj4U="
+}

--- a/legacy_event_data/firebase-db5.json
+++ b/legacy_event_data/firebase-db5.json
@@ -1,0 +1,28 @@
+{
+  "eventType": "providers/google.firebase.database/eventTypes/ref.write",
+  "params": {
+    "child": "xyz"
+  },
+  "auth": {
+    "admin": true
+  },
+  "data": {
+    "data": {
+      "deeply": {
+        "nested": {
+          "text": "This is deeply nested",
+          "text2": "Second value"
+        }
+      },
+      "grandchild": "other changed"
+    },
+    "delta": {
+      "deeply": {
+        "abc": "def"
+      }
+    }
+  },
+  "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+  "timestamp": "2020-05-21T11:21:07.809Z",
+  "eventId": "9WBpn32ssA33ympcsuq/5JJmnDM="
+}

--- a/legacy_event_data/firebase-db6.json
+++ b/legacy_event_data/firebase-db6.json
@@ -1,0 +1,29 @@
+{
+  "eventType": "providers/google.firebase.database/eventTypes/ref.write",
+  "params": {
+    "child": "xyz"
+  },
+  "auth": {
+    "admin": true
+  },
+  "data": {
+    "data": {
+      "deeply": {
+        "abc": "def",
+        "nested": {
+          "text": "This is deeply nested",
+          "text2": "Second value"
+        }
+      },
+      "grandchild": "other changed"
+    },
+    "delta": {
+      "deeply": {
+        "nested": null
+      }
+    }
+  },
+  "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+  "timestamp": "2020-05-21T11:22:36.728Z",
+  "eventId": "mtM1+41X04VNxshbrbl7ua3wnTI="
+}

--- a/legacy_event_data/firebase-db7.json
+++ b/legacy_event_data/firebase-db7.json
@@ -1,0 +1,25 @@
+{
+  "eventType": "providers/google.firebase.database/eventTypes/ref.write",
+  "params": {
+    "child": "xyz"
+  },
+  "auth": {
+    "admin": true
+  },
+  "data": {
+    "data": {
+      "deeply": {
+        "abc": "def"
+      },
+      "grandchild": "other changed"
+    },
+    "delta": {
+      "deeply": {
+        "abc": 10
+      }
+    }
+  },
+  "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+  "timestamp": "2020-05-21T11:23:46.225Z",
+  "eventId": "fvnCmPWm8q4PPEKFRfrjuNxbQ00="
+}

--- a/legacy_event_data/firebase-db8.json
+++ b/legacy_event_data/firebase-db8.json
@@ -1,0 +1,35 @@
+{
+  "eventType": "providers/google.firebase.database/eventTypes/ref.write",
+  "params": {
+  },
+  "auth": {
+    "admin": true
+  },
+  "data": {
+    "data": {
+      "gcf-test": {
+        "abc": 10,
+        "child1": "value1",
+        "xyz": {
+          "deeply": {
+            "abc": 11
+          },
+          "grandchild": "other changed"
+        }
+      },
+      "not-gcf-test": "Foo"
+    },
+    "delta": {
+      "gcf-test": {
+        "xyz": {
+          "deeply": {
+            "abc": 12
+          }
+        }
+      }
+    }
+  },
+  "resource": "projects/_/instances/my-project-id/refs/",
+  "timestamp": "2020-05-21T11:33:01.789Z",
+  "eventId": "MazIvLoUshV35XHwjH+2rfP7uvk="
+}

--- a/legacy_event_data/firebase-dbdelete1.json
+++ b/legacy_event_data/firebase-dbdelete1.json
@@ -1,0 +1,18 @@
+{
+  "eventType": "providers/google.firebase.database/eventTypes/ref.delete",
+  "params": {
+    "child": "xyz"
+  },
+  "auth": {
+    "admin": true
+  },
+  "data": {
+    "data": {
+      "grandchild": "other changed"
+    },
+    "delta": null
+  },
+  "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+  "timestamp": "2020-05-21T11:53:45.337Z",
+  "eventId": "oIcVXHEMZfhQMNs/yD4nwpuKE0s="
+}

--- a/legacy_event_data/firebase-dbdelete2.json
+++ b/legacy_event_data/firebase-dbdelete2.json
@@ -1,0 +1,16 @@
+{
+  "eventType": "providers/google.firebase.database/eventTypes/ref.delete",
+  "params": {
+    "child": "abc"
+  },
+  "auth": {
+    "admin": true
+  },
+  "data": {
+    "data": 10,
+    "delta": null
+  },
+  "resource": "projects/_/instances/my-project-id/refs/gcf-test/abc",
+  "timestamp": "2020-05-21T11:56:12.833Z",
+  "eventId": "KVLKeFKjFP2jepddr+EPGC0ZQ20="
+}

--- a/legacy_event_data/firestore_complex.json
+++ b/legacy_event_data/firestore_complex.json
@@ -1,0 +1,81 @@
+{
+  "data": {
+    "oldValue": {},
+    "updateMask": {},
+    "value": {
+      "createTime": "2020-04-23T14:25:05.349632Z",
+      "fields": {
+        "arrayValue": {
+          "arrayValue": {
+            "values": [
+              {
+                "integerValue": "1"
+              },
+              {
+                "integerValue": "2"
+              }
+            ]
+          }
+        },
+        "booleanValue": {
+          "booleanValue": true
+        },
+        "doubleValue": {
+          "doubleValue": 5.5
+        },
+        "geoPointValue": {
+          "geoPointValue": {
+            "latitude": 51.4543,
+            "longitude": -0.9781
+          }
+        },
+        "intValue": {
+          "integerValue": "50"
+        },
+        "mapValue": {
+          "mapValue": {
+            "fields": {
+              "field1": {
+                "stringValue": "x"
+              },
+              "field2": {
+                "arrayValue": {
+                  "values": [
+                    {
+                      "stringValue": "x"
+                    },
+                    {
+                      "integerValue": "1"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "nullValue": {
+          "nullValue": null
+        },
+        "referenceValue": {
+          "referenceValue": "projects/project-id/databases/(default)/documents/foo/bar/baz/qux"
+        },
+        "stringValue": {
+          "stringValue": "text"
+        },
+        "timestampValue": {
+          "timestampValue": "2020-04-23T14:23:53.241Z"
+        }
+      },
+      "name": "projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
+      "updateTime": "2020-04-23T14:25:05.349632Z"
+    }
+  },
+  "eventId": "9babded5-e5f2-41af-a46a-06ba6bd84739-0",
+  "eventType": "providers/cloud.firestore/eventTypes/document.write",
+  "notSupported": {},
+  "params": {
+    "doc": "IH75dRdeYJKd4uuQiqch"
+  },
+  "resource": "projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
+  "timestamp": "2020-04-23T14:25:05.349632Z"
+}

--- a/legacy_event_data/firestore_simple.json
+++ b/legacy_event_data/firestore_simple.json
@@ -1,0 +1,51 @@
+﻿{
+   "data":{
+      "oldValue":{
+         "createTime":"2020-04-23T09:58:53.211035Z",
+         "fields":{
+            "another test":{
+               "stringValue":"asd"
+            },
+            "count":{
+               "integerValue":"3"
+            },
+            "foo":{
+               "stringValue":"bar"
+            }
+         },
+         "name":"projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
+         "updateTime":"2020-04-23T12:00:27.247187Z"
+      },
+      "updateMask":{
+         "fieldPaths":[
+            "count"
+         ]
+      },
+      "value":{
+         "createTime":"2020-04-23T09:58:53.211035Z",
+         "fields":{
+            "another test":{
+               "stringValue":"asd"
+            },
+            "count":{
+               "integerValue":"4"
+            },
+            "foo":{
+               "stringValue":"bar"
+            }
+         },
+         "name":"projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
+         "updateTime":"2020-04-23T12:00:27.247187Z"
+      }
+   },
+   "eventId":"7b8f1804-d38b-4b68-b37d-e2fb5d12d5a0-0",
+   "eventType":"providers/cloud.firestore/eventTypes/document.write",
+   "notSupported":{
+
+   },
+   "params":{
+      "doc":"2Vm2mI1d0wIaK2Waj5to"
+   },
+   "resource":"projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
+   "timestamp":"2020-04-23T12:00:27.247187Z"
+}

--- a/legacy_event_data/legacy_pubsub.json
+++ b/legacy_event_data/legacy_pubsub.json
@@ -1,0 +1,13 @@
+{
+  "eventId": "1215011316659232",
+  "timestamp": "2020-05-18T12:13:19.209Z",
+  "eventType": "providers/cloud.pubsub/eventTypes/topic.publish",
+  "resource": "projects/sample-project/topics/gcf-test",
+  "data": {
+    "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+    "attributes": {
+      "attribute1": "value1"
+    },
+    "data": "VGhpcyBpcyBhIHNhbXBsZSBtZXNzYWdl"
+  }
+}

--- a/legacy_event_data/legacy_storage_change.json
+++ b/legacy_event_data/legacy_storage_change.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "bucket": "sample-bucket",
+    "crc32c": "AAAAAA==",
+    "etag": "COu8mb3Dn+kCEAE=",
+    "generation": "1588778055917163",
+    "id": "sample-bucket/MyFile/1588778055917163",
+    "kind": "storage#object",
+    "md5Hash": "ZDQxZDhjZDk4ZjAwYjIwNGU5ODAwOTk4ZWNmODQyN2U=",
+    "mediaLink": "https://www.googleapis.com/download/storage/v1/b/projectid-sample-bucket/o/MyFile?generation=1588778055917163\u0026alt=media",
+    "metageneration": "1",
+    "name": "MyFile",
+    "resourceState": "not_exists",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/projectid-sample-bucket/o/MyFile",
+    "size": "0",
+    "storageClass": "MULTI_REGIONAL",
+    "timeCreated": "2020-05-06T15:14:15.917Z",
+    "timeDeleted": "2020-05-18T09:07:51.799Z",
+    "timeStorageClassUpdated": "2020-05-06T15:14:15.917Z",
+    "updated": "2020-05-06T15:14:15.917Z"
+  },
+  "eventId": "1200401551653202",
+  "eventType": "providers/cloud.storage/eventTypes/object.change",
+  "resource": "projects/_/buckets/sample-bucket/objects/MyFile#1588778055917163",
+  "timestamp": "2020-05-18T09:07:51.799Z"
+}

--- a/legacy_event_data/pubsub_binary.json
+++ b/legacy_event_data/pubsub_binary.json
@@ -1,0 +1,16 @@
+﻿{
+   "context": {
+      "eventId":"1144231683168617",
+      "timestamp":"2020-05-06T07:33:34.556Z",
+      "eventType":"google.pubsub.topic.publish",
+      "resource":{
+        "service":"pubsub.googleapis.com",
+        "name":"projects/sample-project/topics/gcf-test",
+        "type":"type.googleapis.com/google.pubsub.v1.PubsubMessage"
+      }
+   },
+   "data": {
+      "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+      "data": "AQIDBA=="
+   }
+}

--- a/legacy_event_data/pubsub_text.json
+++ b/legacy_event_data/pubsub_text.json
@@ -1,0 +1,19 @@
+﻿{
+   "context": {
+      "eventId":"1144231683168617",
+      "timestamp":"2020-05-06T07:33:34.556Z",
+      "eventType":"google.pubsub.topic.publish",
+      "resource":{
+        "service":"pubsub.googleapis.com",
+        "name":"projects/sample-project/topics/gcf-test",
+        "type":"type.googleapis.com/google.pubsub.v1.PubsubMessage"
+      }
+   },
+   "data": {
+      "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+      "attributes": {
+         "attr1":"attr1-value"
+      },
+      "data": "dGVzdCBtZXNzYWdlIDM="
+   }
+}

--- a/legacy_event_data/storage.json
+++ b/legacy_event_data/storage.json
@@ -1,0 +1,31 @@
+﻿{
+   "context": {
+      "eventId": "1147091835525187",
+      "timestamp": "2020-04-23T07:38:57.772Z",
+      "eventType": "google.storage.object.finalize",
+      "resource": {
+         "service": "storage.googleapis.com",
+         "name": "projects/_/buckets/some-bucket/objects/folder/Test.cs",
+         "type": "storage#object"
+      }
+   },
+   "data": {
+      "bucket": "some-bucket",
+      "contentType": "text/plain",
+      "crc32c": "rTVTeQ==",
+      "etag": "CNHZkbuF/ugCEAE=",
+      "generation": "1587627537231057",
+      "id": "some-bucket/folder/Test.cs/1587627537231057",
+      "kind": "storage#object",
+      "md5Hash": "kF8MuJ5+CTJxvyhHS1xzRg==",
+      "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/folder%2FTest.cs?generation=1587627537231057\u0026alt=media",
+      "metageneration": "1",
+      "name": "folder/Test.cs",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/folder/Test.cs",
+      "size": "352",
+      "storageClass": "MULTI_REGIONAL",
+      "timeCreated": "2020-04-23T07:38:57.230Z",
+      "timeStorageClassUpdated": "2020-04-23T07:38:57.230Z",
+      "updated": "2020-04-23T07:38:57.230Z"
+   }
+}


### PR DESCRIPTION
Adds the source of truth legacy event data to the FF conformance repo.

We currently have test data in our individual FFs. Eventually we want to ensure that we can accept these payloads in conformance tests.

- https://github.com/GoogleCloudPlatform/functions-framework-dotnet/tree/master/src/Google.Cloud.Functions.Framework.Tests/GcfEvents
- https://github.com/GoogleCloudPlatform/functions-framework-ruby/tree/master/test/legacy_events_data