### PR TITLE
Field-wise validation for CloudEvents

### DIFF
--- a/events/validators.go
+++ b/events/validators.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/go-cmp/cmp"
 )
 
 // ValidateEvent validates that a particular function output matches the expected contents.
@@ -101,19 +102,15 @@ func validateCloudEvent(name string, gotBytes, wantBytes []byte) error {
 		},
 		{
 			name:      "data",
-			gotValue:  string(got.DataEncoded),
-			wantValue: string(want.DataEncoded),
+			gotValue:  got.DataEncoded,
+			wantValue: want.DataEncoded,
 		},
 	}
 	for _, field := range fields {
-		if field.gotValue != field.wantValue {
+		if !cmp.Equal(field.gotValue, field.wantValue) {
 			return fmt.Errorf("unexpected %q field in %q: got %v, want %v", field.name, name, field.gotValue, field.wantValue)
 		}
 	}
 
-	// Check the time field specially.
-	if !gotContext.Time.Time.Equal(wantContext.Time.Time) {
-		return fmt.Errorf("unexpected 'time' field in %q: got %v, want %v", name, gotContext.Time, wantContext.Time)
-	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	cloud.google.com/go v0.58.0 // indirect
 	github.com/cloudevents/sdk-go/v2 v2.0.0
+	github.com/google/go-cmp v0.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=


### PR DESCRIPTION
Rather than just using a string output, validate cloud events by field. Allows for more fine-grained control if we need to do additional validation on the different fields.