### PR TITLE
feat: support validation of container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ Frameworks to the Functions Framework contract.
 Usage of client:
 
   -cmd string
-        command to run a Functions Framework server at localhost:8080
+        command or container image to run a Functions Framework server at localhost:8080
   -type string
         type of function to validate (must be 'http', 'cloudevent', or 'legacyevent' (default "http")
   -validate-mapping
         whether to validate mapping from legacy->cloud events and vice versa (as applicable) (default true)
+  -run-in-container
+        whether to run a Functions Framework server in a container (default false)
 ```

--- a/client/main.go
+++ b/client/main.go
@@ -22,10 +22,10 @@ import (
 )
 
 var (
-	cmd             = flag.String("cmd", "", "command to run a Functions Framework server at localhost:8080")
+	cmd             = flag.String("cmd", "", "command or container image to run a Functions Framework server at localhost:8080")
 	functionType    = flag.String("type", "http", "type of function to validate (must be 'http', 'cloudevent', or 'legacyevent'")
 	validateMapping = flag.Bool("validate-mapping", true, "whether to validate mapping from legacy->cloud events and vice versa (as applicable)")
-	runInContainer  = flag.Bool("run-in-container", false, "whether the Functions Framework server is running in a container")
+	runInContainer  = flag.Bool("run-in-container", false, "whether to run a Functions Framework server in a container")
 )
 
 func runValidation() error {

--- a/client/main.go
+++ b/client/main.go
@@ -25,19 +25,20 @@ var (
 	cmd             = flag.String("cmd", "", "command to run a Functions Framework server at localhost:8080")
 	functionType    = flag.String("type", "http", "type of function to validate (must be 'http', 'cloudevent', or 'legacyevent'")
 	validateMapping = flag.Bool("validate-mapping", true, "whether to validate mapping from legacy->cloud events and vice versa (as applicable)")
+	runInContainer  = flag.Bool("run-in-container", false, "whether the Functions Framework server is running in a container")
 )
 
 func runValidation() error {
 	log.Printf("Validating %q for %s...", *cmd, *functionType)
 
-	shutdown, err := start(*cmd)
+	shutdown, err := start(*cmd, *runInContainer)
 	defer shutdown()
 
 	if err != nil {
 		return fmt.Errorf("unable to start server: %v", err)
 	}
 
-	if err := validate("http://localhost:8080", *functionType, *validateMapping); err != nil {
+	if err := validate("http://localhost:8080", *functionType, *validateMapping, *runInContainer); err != nil {
 		return fmt.Errorf("Validation failure: %v", err)
 	}
 

--- a/client/validate.go
+++ b/client/validate.go
@@ -113,6 +113,9 @@ func validate(url, functionType string, validateMapping, runInContainer bool) er
 }
 
 func getOutput(runInContainer bool) ([]byte, error) {
+	if !runInContainer {
+		return ioutil.ReadFile(outputFile)
+	}
 	cmd := exec.Command("docker", "ps", "--latest", "--format", "{{.ID}}")
 	containerID, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
When the flag `-run-in-container` (false by default) is set to true, we run the functions framework in a container. The function output file will be copied to the local file system for the validation. This can be used to validate container images built by our buildpacks. For example, to validate a function image called `fn-image`, run
```
./client -cmd="fn-image" -type="http" -run-in-container="true"
```