### PR TITLE
Improve error reporting

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -35,6 +35,16 @@ const (
 	CloudEvent
 )
 
+func (e EventType) String() string {
+	switch e {
+	case LegacyEvent:
+		return "legacy event"
+	case CloudEvent:
+		return "cloud event"
+	}
+	return ""
+}
+
 // EventNames returns a list of event names to use as inputs for a particular event type.
 func EventNames(t EventType) ([]string, error) {
 	eventNames := []string{}


### PR DESCRIPTION
Collect errors and report as a whole, rather than bailing on the first
error. Also report which events have been tested and why any were
skipped.