### PR TITLE
Loosen requirements on the data payload of CloudEvents.

### DIFF
--- a/events/validators.go
+++ b/events/validators.go
@@ -224,8 +224,8 @@ func validateCloudEvent(name string, gotBytes, wantBytes []byte) *ValidationInfo
 		},
 		{
 			name:      "data",
-			gotValue:  string(got.Data()),
-			wantValue: string(want.Data()),
+			gotValue:  unmarshalMap(got.Data(), vi),
+			wantValue: unmarshalMap(want.Data(), vi),
 		},
 	}
 	for _, field := range fields {
@@ -236,3 +236,10 @@ func validateCloudEvent(name string, gotBytes, wantBytes []byte) *ValidationInfo
 
 	return vi
 }
+
+func unmarshalMap(data []byte, vi *ValidationInfo) (dataMap map[string]interface{}) {
+	if err := json.Unmarshal(data, &dataMap); err != nil {
+		vi.Errs = append(vi.Errs, fmt.Errorf("could not parse CloudEvent data as map: %v", err))
+	}
+	return
+}  


### PR DESCRIPTION
When a legacy event is converted to a CloudEvent, we know that we want a certain
JSON payload, but we shouldn't require that payload to be formatted exactly the
same as the JSON payload in our golden files. Instead, we unmarshal both the
actual and expected values into maps, and we check that those maps are equal.