### PR TITLE
fix: run `go get` in conformance action

### DIFF
--- a/action/src/index.ts
+++ b/action/src/index.ts
@@ -42,7 +42,7 @@ async function run() {
 
   // Install conformance client binary.
   runCmd(
-      'go install github.com/GoogleCloudPlatform/functions-framework-conformance/client');
+      'go get github.com/GoogleCloudPlatform/functions-framework-conformance/client');
 
   // Run the client with the specified parameters.
   runCmd([


### PR DESCRIPTION
When using the action in other functions frameworks' CI workflows, the comformance tool is not local so `go install` would fail with the error
```
can't load package: package github.com/GoogleCloudPlatform/functions-framework-conformance/client: cannot find package "github.com/GoogleCloudPlatform/functions-framework-conformance/client" in any of:
	/opt/hostedtoolcache/go/1.13.15/x64/src/github.com/GoogleCloudPlatform/functions-framework-conformance/client (from $GOROOT)
	/home/runner/go/src/github.com/GoogleCloudPlatform/functions-framework-conformance/client (from $GOPATH)
```
Using `go get` will both download and install the conformance tool.