### PR TITLE
fix: use input data as the expected values for "CloudEvents to CloudEvents" tests

### DIFF
--- a/client/validate.go
+++ b/client/validate.go
@@ -140,7 +140,7 @@ func (v validator) validateEvents(url string, inputType, outputType events.Event
 		if err != nil {
 			return fmt.Errorf("reading output file from function for %q: %v", name, err)
 		}
-		if vi := events.ValidateEvent(name, outputType, output); vi != nil {
+		if vi := events.ValidateEvent(name, inputType, outputType, output); vi != nil {
 			vis = append(vis, vi)
 		}
 	}

--- a/events/validators.go
+++ b/events/validators.go
@@ -67,8 +67,15 @@ func PrintValidationInfos(vis []*ValidationInfo) (string, error) {
 }
 
 // ValidateEvent validates that a particular function output matches the expected contents.
-func ValidateEvent(name string, t EventType, got []byte) *ValidationInfo {
-	want := OutputData(name, t)
+func ValidateEvent(name string, it EventType, ot EventType, got []byte) *ValidationInfo {
+	want := OutputData(name, ot)
+
+	// If validating CloudEvent to CloudEvent (no event conversions),
+	// the output data should be exactly the same as the input data.
+	if it == CloudEvent && ot == CloudEvent {
+		want = InputData(name, it)
+	}
+
 	if want == nil {
 		// Include the possibilities in the error.
 		return &ValidationInfo{

--- a/events/validators.go
+++ b/events/validators.go
@@ -80,11 +80,11 @@ func ValidateEvent(name string, it EventType, ot EventType, got []byte) *Validat
 		// Include the possibilities in the error.
 		return &ValidationInfo{
 			Name:          name,
-			SkippedReason: fmt.Sprintf("no expected output value of type %s", t),
+			SkippedReason: fmt.Sprintf("no expected output value of type %s", ot),
 		}
 	}
 
-	switch t {
+	switch ot {
 	case LegacyEvent:
 		return validateLegacyEvent(name, got, want)
 	case CloudEvent:

--- a/events/validators_test.go
+++ b/events/validators_test.go
@@ -26,19 +26,19 @@ func TestValidateLegacyEvent(t *testing.T) {
 		t.Fatalf("no legacy event data")
 	}
 	// Validate the event output against itself.
-	if vi := ValidateEvent(testName, LegacyEvent, data); vi.Errs != nil {
+	if vi := ValidateEvent(testName, LegacyEvent, LegacyEvent, data); vi.Errs != nil {
 		t.Errorf("validating legacy event: %v", vi.Errs)
 	}
 }
 
 func TestValidateCloudEvent(t *testing.T) {
 	testName := "firebase-auth"
-	data := OutputData(testName, CloudEvent)
+	data := InputData(testName, CloudEvent)
 	if data == nil {
 		t.Fatalf("no cloudevent data")
 	}
 	// Validate the event output against itself.
-	if vi := ValidateEvent(testName, CloudEvent, data); vi.Errs != nil {
+	if vi := ValidateEvent(testName, CloudEvent, CloudEvent, data); vi.Errs != nil {
 		t.Errorf("validating cloudevent: %v", vi.Errs)
 	}
 }


### PR DESCRIPTION
As issue #54, this allow modifying the CloudEvent "input" files without breaking the "CloudEvents to CloudEvents" tests.