### PR TITLE
Override the expected converted Pub/Sub payload

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -79,11 +79,17 @@ func InputData(name string, t EventType) []byte {
 }
 
 // OutputData returns the contents of the output event for a particular event name and type.
-func OutputData(name string, t EventType) []byte {
+func OutputData(name string, t EventType, isConversion bool) []byte {
 	switch t {
 	case LegacyEvent:
+		if isConversion && Events[name].ConvertedOutput.LegacyEvent != nil {
+			return Events[name].ConvertedOutput.LegacyEvent
+		}
 		return Events[name].Output.LegacyEvent
 	case CloudEvent:
+		if isConversion && Events[name].ConvertedOutput.CloudEvent != nil {
+			return Events[name].ConvertedOutput.CloudEvent
+		}
 		return Events[name].Output.CloudEvent
 	}
 	return nil

--- a/events/events_data.go
+++ b/events/events_data.go
@@ -8,8 +8,9 @@ type EventData struct {
 }
 
 type Event struct {
-	Input  EventData
-	Output EventData
+	Input           EventData
+	Output          EventData
+	ConvertedOutput EventData
 }
 
 var Events = map[string]Event{
@@ -116,6 +117,8 @@ var Events = map[string]Event{
 }
 `),
 		},
+		ConvertedOutput: EventData{
+		},
 	},
 
 	"firebase-db1": {
@@ -188,6 +191,8 @@ var Events = map[string]Event{
   }
 }
 `),
+		},
+		ConvertedOutput: EventData{
 		},
 	},
 
@@ -268,6 +273,8 @@ var Events = map[string]Event{
   }
 }`),
 		},
+		ConvertedOutput: EventData{
+		},
 	},
 
 	"firebase-db3": {
@@ -330,6 +337,8 @@ var Events = map[string]Event{
     "delta": 10
   }
 }`),
+		},
+		ConvertedOutput: EventData{
 		},
 	},
 
@@ -429,6 +438,8 @@ var Events = map[string]Event{
     }
   }
 }`),
+		},
+		ConvertedOutput: EventData{
 		},
 	},
 
@@ -540,6 +551,8 @@ var Events = map[string]Event{
     }
   }
 }`),
+		},
+		ConvertedOutput: EventData{
 		},
 	},
 
@@ -658,6 +671,8 @@ var Events = map[string]Event{
 }
 `),
 		},
+		ConvertedOutput: EventData{
+		},
 	},
 
 	"firebase-db7": {
@@ -758,6 +773,8 @@ var Events = map[string]Event{
   }
 }
 `),
+		},
+		ConvertedOutput: EventData{
 		},
 	},
 
@@ -903,6 +920,8 @@ var Events = map[string]Event{
 }
 `),
 		},
+		ConvertedOutput: EventData{
+		},
 	},
 
 	"firebase-dbdelete1": {
@@ -976,6 +995,8 @@ var Events = map[string]Event{
 }
 `),
 		},
+		ConvertedOutput: EventData{
+		},
 	},
 
 	"firebase-dbdelete2": {
@@ -1040,6 +1061,8 @@ var Events = map[string]Event{
   }
 }
 `),
+		},
+		ConvertedOutput: EventData{
 		},
 	},
 
@@ -1372,6 +1395,8 @@ var Events = map[string]Event{
 }
 `),
 		},
+		ConvertedOutput: EventData{
+		},
 	},
 
 	"firestore_simple": {
@@ -1577,6 +1602,8 @@ var Events = map[string]Event{
 }
 `),
 		},
+		ConvertedOutput: EventData{
+		},
 	},
 
 	"legacy_pubsub": {
@@ -1647,6 +1674,28 @@ var Events = map[string]Event{
       },
       "data": "VGhpcyBpcyBhIHNhbXBsZSBtZXNzYWdl"
     }
+  }
+}
+`),
+		},
+		ConvertedOutput: EventData{
+			LegacyEvent: []byte(`{
+  "context": {
+    "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+    "timestamp": "2020-09-29T11:32:00.000Z",
+    "eventType":"google.pubsub.topic.publish",
+    "resource": {
+      "service":"pubsub.googleapis.com",
+      "name":"projects/sample-project/topics/gcf-test",
+      "type":"type.googleapis.com/google.pubsub.v1.PubsubMessage"
+    }
+  },
+  "data": {
+    "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+    "attributes": {
+      "attribute1": "value1"
+    },
+    "data": "VGhpcyBpcyBhIHNhbXBsZSBtZXNzYWdl"
   }
 }
 `),
@@ -1722,6 +1771,8 @@ var Events = map[string]Event{
   }
 }
 `),
+		},
+		ConvertedOutput: EventData{
 		},
 	},
 
@@ -1806,6 +1857,8 @@ var Events = map[string]Event{
   }
 }
 `),
+		},
+		ConvertedOutput: EventData{
 		},
 	},
 
@@ -1935,6 +1988,8 @@ var Events = map[string]Event{
   }
 }
 `),
+		},
+		ConvertedOutput: EventData{
 		},
 	},
 }

--- a/events/generate/data/README.md
+++ b/events/generate/data/README.md
@@ -28,6 +28,16 @@ Generally, try to stay consistent across tests for the following fields (arbitra
 - Timestamp: "2020-09-29T11:32:00.000Z"
 - Project ID: my-project-id
 
+The `output-converted.json` suffix can be used to override the expected output
+when converting between event types. For example, consider the following files:
+
+-   `newevent-legacy-output.json`
+-   `newevent-legacy-output-converted.json`
+
+The `newevent-legacy-output.json` file will be used to validate legacy events,
+and `newevent-legacy-output-converted.json` will be used to validate converting
+between cloud events and legacy events.
+
 Once you have the input and output data, generate the test cases to embed them
 in the binary. Run the following:
 

--- a/events/generate/data/legacy_pubsub-legacy-output-converted.json
+++ b/events/generate/data/legacy_pubsub-legacy-output-converted.json
@@ -1,0 +1,19 @@
+{
+  "context": {
+    "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+    "timestamp": "2020-09-29T11:32:00.000Z",
+    "eventType":"google.pubsub.topic.publish",
+    "resource": {
+      "service":"pubsub.googleapis.com",
+      "name":"projects/sample-project/topics/gcf-test",
+      "type":"type.googleapis.com/google.pubsub.v1.PubsubMessage"
+    }
+  },
+  "data": {
+    "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+    "attributes": {
+      "attribute1": "value1"
+    },
+    "data": "VGhpcyBpcyBhIHNhbXBsZSBtZXNzYWdl"
+  }
+}

--- a/events/validators.go
+++ b/events/validators.go
@@ -68,7 +68,7 @@ func PrintValidationInfos(vis []*ValidationInfo) (string, error) {
 
 // ValidateEvent validates that a particular function output matches the expected contents.
 func ValidateEvent(name string, it EventType, ot EventType, got []byte) *ValidationInfo {
-	want := OutputData(name, ot)
+	want := OutputData(name, ot, it != ot)
 
 	// If validating CloudEvent to CloudEvent (no event conversions),
 	// the output data should be exactly the same as the input data.

--- a/events/validators_test.go
+++ b/events/validators_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestValidateLegacyEvent(t *testing.T) {
 	testName := "firebase-auth"
-	data := OutputData(testName, LegacyEvent)
+	data := OutputData(testName, LegacyEvent, false)
 	if data == nil {
 		t.Fatalf("no legacy event data")
 	}


### PR DESCRIPTION
There are multiple legacy Pub/Sub payload schemas. For example, see:

- `legacy_pubsub-legacy-output.json`
- `pubsub_text-legacy-output.json`

When converting Cloud Events to legacy events there is no information
in the CE that enables us to infer which schema to use for the conversion.
Unfortunately, this tool assumes the converted output will always match
a corresponding unconverted payload, which isn't necessarily possible.

This commit adds a mechanism to override the expected output when
converting between event types and creates an override for converting
the `legacy_pubsub` test case.