### PR TITLE
fix: use non-zero ending timestamps for event data

### DIFF
--- a/events/events_data.go
+++ b/events/events_data.go
@@ -37,7 +37,7 @@ var Events = map[string]Event{
   "notSupported": {
   },
   "resource": "projects/my-project-id",
-  "timestamp": "2020-09-29T11:32:00.000Z"
+  "timestamp": "2020-09-29T11:32:00.123Z"
 }
 `),
 			CloudEvent: []byte(`{
@@ -46,7 +46,7 @@ var Events = map[string]Event{
   "source": "//firebaseauth.googleapis.com/projects/my-project-id",
   "subject": "users/UUpby3s4spZre6kHsgVSPetzQ8l2",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "email": "test@nowhere.com",
@@ -87,7 +87,7 @@ var Events = map[string]Event{
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
     "eventType": "providers/firebase.auth/eventTypes/user.create",
     "resource": "projects/my-project-id",
-    "timestamp": "2020-09-29T11:32:00.000Z"
+    "timestamp": "2020-09-29T11:32:00.123Z"
   }
 }
 `),
@@ -97,7 +97,7 @@ var Events = map[string]Event{
   "source": "//firebaseauth.googleapis.com/projects/my-project-id",
   "subject": "users/UUpby3s4spZre6kHsgVSPetzQ8l2",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "email": "test@nowhere.com",
@@ -139,7 +139,7 @@ var Events = map[string]Event{
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }
 `),
@@ -149,7 +149,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": null,
@@ -170,7 +170,7 @@ var Events = map[string]Event{
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write" 
   }
@@ -182,7 +182,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": null,
@@ -217,7 +217,7 @@ var Events = map[string]Event{
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }
 `),
@@ -227,7 +227,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -251,7 +251,7 @@ var Events = map[string]Event{
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }
@@ -263,7 +263,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -295,7 +295,7 @@ var Events = map[string]Event{
     "delta": 10
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }
 `),
@@ -305,7 +305,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": null,
@@ -321,7 +321,7 @@ var Events = map[string]Event{
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }
@@ -333,7 +333,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": null,
@@ -370,7 +370,7 @@ var Events = map[string]Event{
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }
 `),
@@ -380,7 +380,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -415,7 +415,7 @@ var Events = map[string]Event{
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }
 }
@@ -426,7 +426,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -475,7 +475,7 @@ var Events = map[string]Event{
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }
 `),
@@ -485,7 +485,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -525,7 +525,7 @@ var Events = map[string]Event{
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }
@@ -537,7 +537,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -590,7 +590,7 @@ var Events = map[string]Event{
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }
 `),
@@ -600,7 +600,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -643,7 +643,7 @@ var Events = map[string]Event{
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }
@@ -655,7 +655,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -706,7 +706,7 @@ var Events = map[string]Event{
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }
 `),
@@ -716,7 +716,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -752,7 +752,7 @@ var Events = map[string]Event{
   "context": {
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }
 }
@@ -763,7 +763,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -820,7 +820,7 @@ var Events = map[string]Event{
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }
 `),
@@ -830,7 +830,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -887,7 +887,7 @@ var Events = map[string]Event{
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }
@@ -899,7 +899,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -950,7 +950,7 @@ var Events = map[string]Event{
     "delta": null
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }
 `),
@@ -960,7 +960,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -981,7 +981,7 @@ var Events = map[string]Event{
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.delete",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }
@@ -993,7 +993,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {
@@ -1024,7 +1024,7 @@ var Events = map[string]Event{
     "delta": null
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }
 `),
@@ -1034,7 +1034,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": 10,
@@ -1051,7 +1051,7 @@ var Events = map[string]Event{
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.delete",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }
@@ -1063,7 +1063,7 @@ var Events = map[string]Event{
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": 10,
@@ -1157,7 +1157,7 @@ var Events = map[string]Event{
     "doc": "IH75dRdeYJKd4uuQiqch"
   },
   "resource": "projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
-  "timestamp": "2020-09-29T11:32:00.000Z"
+  "timestamp": "2020-09-29T11:32:00.123Z"
 }
 `),
 			CloudEvent: []byte(`{
@@ -1166,7 +1166,7 @@ var Events = map[string]Event{
   "source": "//firestore.googleapis.com/projects/project-id/databases/(default)",
   "subject": "documents/gcf-test/IH75dRdeYJKd4uuQiqch",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "oldValue": {},
@@ -1319,7 +1319,7 @@ var Events = map[string]Event{
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
     "eventType": "providers/cloud.firestore/eventTypes/document.write",
     "resource": "projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
-    "timestamp": "2020-09-29T11:32:00.000Z"
+    "timestamp": "2020-09-29T11:32:00.123Z"
   }
 }
 `),
@@ -1329,7 +1329,7 @@ var Events = map[string]Event{
   "source": "//firestore.googleapis.com/projects/project-id/databases/(default)",
   "subject": "documents/gcf-test/IH75dRdeYJKd4uuQiqch",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "oldValue": {},
@@ -1460,7 +1460,7 @@ var Events = map[string]Event{
       "doc":"2Vm2mI1d0wIaK2Waj5to"
    },
    "resource":"projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
-   "timestamp":"2020-09-29T11:32:00.000Z"
+   "timestamp":"2020-09-29T11:32:00.123Z"
 }
 `),
 			CloudEvent: []byte(`{
@@ -1469,7 +1469,7 @@ var Events = map[string]Event{
   "source": "//firestore.googleapis.com/projects/project-id/databases/(default)",
   "subject": "documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "oldValue":{
@@ -1558,7 +1558,7 @@ var Events = map[string]Event{
      "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
      "eventType":"providers/cloud.firestore/eventTypes/document.write",
      "resource":"projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
-     "timestamp":"2020-09-29T11:32:00.000Z"
+     "timestamp":"2020-09-29T11:32:00.123Z"
    }
 }
 `),
@@ -1568,7 +1568,7 @@ var Events = map[string]Event{
   "source": "//firestore.googleapis.com/projects/project-id/databases/(default)",
   "subject": "documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "oldValue":{
@@ -1620,7 +1620,7 @@ var Events = map[string]Event{
 		Input: EventData{
 			LegacyEvent: []byte(`{
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventType": "providers/cloud.pubsub/eventTypes/topic.publish",
   "resource": "projects/sample-project/topics/gcf-test",
   "data": {
@@ -1637,14 +1637,14 @@ var Events = map[string]Event{
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "subscription": "projects/sample-project/subscriptions/sample-subscription",
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "attributes": {
         "attribute1": "value1"
       },
@@ -1658,7 +1658,7 @@ var Events = map[string]Event{
 			LegacyEvent: []byte(`{
   "context": {
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/cloud.pubsub/eventTypes/topic.publish",
     "resource": "projects/sample-project/topics/gcf-test"
   },
@@ -1676,13 +1676,13 @@ var Events = map[string]Event{
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "attributes": {
         "attribute1": "value1"
       },
@@ -1696,7 +1696,7 @@ var Events = map[string]Event{
 			LegacyEvent: []byte(`{
   "context": {
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType":"google.pubsub.topic.publish",
     "resource": {
       "service":"pubsub.googleapis.com",
@@ -1721,7 +1721,7 @@ var Events = map[string]Event{
 			LegacyEvent: []byte(`{
    "context": {
       "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp":"2020-09-29T11:32:00.000Z",
+      "timestamp":"2020-09-29T11:32:00.123Z",
       "eventType":"google.pubsub.topic.publish",
       "resource":{
         "service":"pubsub.googleapis.com",
@@ -1740,14 +1740,14 @@ var Events = map[string]Event{
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "subscription": "projects/sample-project/subscriptions/sample-subscription",
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "data": "AQIDBA=="
     }
   }
@@ -1758,7 +1758,7 @@ var Events = map[string]Event{
 			LegacyEvent: []byte(`{
    "context": {
       "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp":"2020-09-29T11:32:00.000Z",
+      "timestamp":"2020-09-29T11:32:00.123Z",
       "eventType":"google.pubsub.topic.publish",
       "resource":{
         "service":"pubsub.googleapis.com",
@@ -1777,13 +1777,13 @@ var Events = map[string]Event{
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "data": "AQIDBA=="
     }
   }
@@ -1799,7 +1799,7 @@ var Events = map[string]Event{
 			LegacyEvent: []byte(`{
    "context": {
       "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp":"2020-09-29T11:32:00.000Z",
+      "timestamp":"2020-09-29T11:32:00.123Z",
       "eventType":"google.pubsub.topic.publish",
       "resource":{
         "service":"pubsub.googleapis.com",
@@ -1821,14 +1821,14 @@ var Events = map[string]Event{
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "subscription": "projects/sample-project/subscriptions/sample-subscription",
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "attributes": {
          "attr1":"attr1-value"
       },
@@ -1842,7 +1842,7 @@ var Events = map[string]Event{
 			LegacyEvent: []byte(`{
    "context": {
       "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp":"2020-09-29T11:32:00.000Z",
+      "timestamp":"2020-09-29T11:32:00.123Z",
       "eventType":"google.pubsub.topic.publish",
       "resource":{
         "service":"pubsub.googleapis.com",
@@ -1864,13 +1864,13 @@ var Events = map[string]Event{
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "attributes": {
          "attr1":"attr1-value"
       },
@@ -1889,7 +1889,7 @@ var Events = map[string]Event{
 			LegacyEvent: []byte(`{
    "context": {
       "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp": "2020-09-29T11:32:00.000Z",
+      "timestamp": "2020-09-29T11:32:00.123Z",
       "eventType": "google.storage.object.finalize",
       "resource": {
          "service": "storage.googleapis.com",
@@ -1924,7 +1924,7 @@ var Events = map[string]Event{
   "source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
   "subject": "objects/folder/Test.cs",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "bucket": "some-bucket",
@@ -1952,7 +1952,7 @@ var Events = map[string]Event{
 			LegacyEvent: []byte(`{
    "context": {
       "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp": "2020-09-29T11:32:00.000Z",
+      "timestamp": "2020-09-29T11:32:00.123Z",
       "eventType": "google.storage.object.finalize",
       "resource": {
          "service": "storage.googleapis.com",
@@ -1987,7 +1987,7 @@ var Events = map[string]Event{
   "source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
   "subject": "objects/folder/Test.cs",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "bucket": "some-bucket",

--- a/events/generate/data/README.md
+++ b/events/generate/data/README.md
@@ -25,7 +25,7 @@ validation test case.
 Generally, try to stay consistent across tests for the following fields (arbitrary values, but consistent ones):
 
 - EventID: "aaaaaa-1111-bbbb-2222-cccccccccccc"
-- Timestamp: "2020-09-29T11:32:00.000Z"
+- Timestamp: "2020-09-29T11:32:00.123Z"
 - Project ID: my-project-id
 
 The `output-converted.json` suffix can be used to override the expected output

--- a/events/generate/data/firebase-auth-cloudevent-input.json
+++ b/events/generate/data/firebase-auth-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firebaseauth.googleapis.com/projects/my-project-id",
   "subject": "users/UUpby3s4spZre6kHsgVSPetzQ8l2",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "email": "test@nowhere.com",

--- a/events/generate/data/firebase-auth-cloudevent-output.json
+++ b/events/generate/data/firebase-auth-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firebaseauth.googleapis.com/projects/my-project-id",
   "subject": "users/UUpby3s4spZre6kHsgVSPetzQ8l2",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "email": "test@nowhere.com",

--- a/events/generate/data/firebase-auth-legacy-input.json
+++ b/events/generate/data/firebase-auth-legacy-input.json
@@ -19,5 +19,5 @@
   "notSupported": {
   },
   "resource": "projects/my-project-id",
-  "timestamp": "2020-09-29T11:32:00.000Z"
+  "timestamp": "2020-09-29T11:32:00.123Z"
 }

--- a/events/generate/data/firebase-auth-legacy-output.json
+++ b/events/generate/data/firebase-auth-legacy-output.json
@@ -18,6 +18,6 @@
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
     "eventType": "providers/firebase.auth/eventTypes/user.create",
     "resource": "projects/my-project-id",
-    "timestamp": "2020-09-29T11:32:00.000Z"
+    "timestamp": "2020-09-29T11:32:00.123Z"
   }
 }

--- a/events/generate/data/firebase-db1-cloudevent-input.json
+++ b/events/generate/data/firebase-db1-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": null,

--- a/events/generate/data/firebase-db1-cloudevent-output.json
+++ b/events/generate/data/firebase-db1-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": null,

--- a/events/generate/data/firebase-db1-legacy-input.json
+++ b/events/generate/data/firebase-db1-legacy-input.json
@@ -14,6 +14,6 @@
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }

--- a/events/generate/data/firebase-db1-legacy-output.json
+++ b/events/generate/data/firebase-db1-legacy-output.json
@@ -7,7 +7,7 @@
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write" 
   }

--- a/events/generate/data/firebase-db2-cloudevent-input.json
+++ b/events/generate/data/firebase-db2-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db2-cloudevent-output.json
+++ b/events/generate/data/firebase-db2-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db2-legacy-input.json
+++ b/events/generate/data/firebase-db2-legacy-input.json
@@ -16,6 +16,6 @@
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }

--- a/events/generate/data/firebase-db2-legacy-output.json
+++ b/events/generate/data/firebase-db2-legacy-output.json
@@ -9,7 +9,7 @@
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }

--- a/events/generate/data/firebase-db3-cloudevent-input.json
+++ b/events/generate/data/firebase-db3-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": null,

--- a/events/generate/data/firebase-db3-cloudevent-output.json
+++ b/events/generate/data/firebase-db3-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": null,

--- a/events/generate/data/firebase-db3-legacy-input.json
+++ b/events/generate/data/firebase-db3-legacy-input.json
@@ -12,6 +12,6 @@
     "delta": 10
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }

--- a/events/generate/data/firebase-db3-legacy-output.json
+++ b/events/generate/data/firebase-db3-legacy-output.json
@@ -5,7 +5,7 @@
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }

--- a/events/generate/data/firebase-db4-cloudevent-input.json
+++ b/events/generate/data/firebase-db4-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db4-cloudevent-output.json
+++ b/events/generate/data/firebase-db4-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db4-legacy-input.json
+++ b/events/generate/data/firebase-db4-legacy-input.json
@@ -21,6 +21,6 @@
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }

--- a/events/generate/data/firebase-db4-legacy-output.json
+++ b/events/generate/data/firebase-db4-legacy-output.json
@@ -15,7 +15,7 @@
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }
 }

--- a/events/generate/data/firebase-db5-cloudevent-input.json
+++ b/events/generate/data/firebase-db5-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db5-cloudevent-output.json
+++ b/events/generate/data/firebase-db5-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db5-legacy-input.json
+++ b/events/generate/data/firebase-db5-legacy-input.json
@@ -24,6 +24,6 @@
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }

--- a/events/generate/data/firebase-db5-legacy-output.json
+++ b/events/generate/data/firebase-db5-legacy-output.json
@@ -17,7 +17,7 @@
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }

--- a/events/generate/data/firebase-db6-cloudevent-input.json
+++ b/events/generate/data/firebase-db6-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db6-cloudevent-output.json
+++ b/events/generate/data/firebase-db6-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db6-legacy-input.json
+++ b/events/generate/data/firebase-db6-legacy-input.json
@@ -25,6 +25,6 @@
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }

--- a/events/generate/data/firebase-db6-legacy-output.json
+++ b/events/generate/data/firebase-db6-legacy-output.json
@@ -18,7 +18,7 @@
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }

--- a/events/generate/data/firebase-db7-cloudevent-input.json
+++ b/events/generate/data/firebase-db7-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db7-cloudevent-output.json
+++ b/events/generate/data/firebase-db7-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db7-legacy-input.json
+++ b/events/generate/data/firebase-db7-legacy-input.json
@@ -21,6 +21,6 @@
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }

--- a/events/generate/data/firebase-db7-legacy-output.json
+++ b/events/generate/data/firebase-db7-legacy-output.json
@@ -15,7 +15,7 @@
   "context": {
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }
 }

--- a/events/generate/data/firebase-db8-cloudevent-input.json
+++ b/events/generate/data/firebase-db8-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db8-cloudevent-output.json
+++ b/events/generate/data/firebase-db8-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-db8-legacy-input.json
+++ b/events/generate/data/firebase-db8-legacy-input.json
@@ -31,6 +31,6 @@
     }
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }

--- a/events/generate/data/firebase-db8-legacy-output.json
+++ b/events/generate/data/firebase-db8-legacy-output.json
@@ -25,7 +25,7 @@
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.write",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }

--- a/events/generate/data/firebase-dbdelete1-cloudevent-input.json
+++ b/events/generate/data/firebase-dbdelete1-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-dbdelete1-cloudevent-output.json
+++ b/events/generate/data/firebase-dbdelete1-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": {

--- a/events/generate/data/firebase-dbdelete1-legacy-input.json
+++ b/events/generate/data/firebase-dbdelete1-legacy-input.json
@@ -14,6 +14,6 @@
     "delta": null
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }

--- a/events/generate/data/firebase-dbdelete1-legacy-output.json
+++ b/events/generate/data/firebase-dbdelete1-legacy-output.json
@@ -7,7 +7,7 @@
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.delete",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }

--- a/events/generate/data/firebase-dbdelete2-cloudevent-input.json
+++ b/events/generate/data/firebase-dbdelete2-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": 10,

--- a/events/generate/data/firebase-dbdelete2-cloudevent-output.json
+++ b/events/generate/data/firebase-dbdelete2-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
   "subject": "refs/gcf-test/xyz",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "data": 10,

--- a/events/generate/data/firebase-dbdelete2-legacy-input.json
+++ b/events/generate/data/firebase-dbdelete2-legacy-input.json
@@ -12,6 +12,6 @@
     "delta": null
   },
   "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 }

--- a/events/generate/data/firebase-dbdelete2-legacy-output.json
+++ b/events/generate/data/firebase-dbdelete2-legacy-output.json
@@ -5,7 +5,7 @@
   },
   "context": {
     "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/google.firebase.database/eventTypes/ref.delete",
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
   }

--- a/events/generate/data/firestore_complex-cloudevent-input.json
+++ b/events/generate/data/firestore_complex-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firestore.googleapis.com/projects/project-id/databases/(default)",
   "subject": "documents/gcf-test/IH75dRdeYJKd4uuQiqch",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "oldValue": {},

--- a/events/generate/data/firestore_complex-cloudevent-output.json
+++ b/events/generate/data/firestore_complex-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firestore.googleapis.com/projects/project-id/databases/(default)",
   "subject": "documents/gcf-test/IH75dRdeYJKd4uuQiqch",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "oldValue": {},

--- a/events/generate/data/firestore_complex-legacy-input.json
+++ b/events/generate/data/firestore_complex-legacy-input.json
@@ -77,5 +77,5 @@
     "doc": "IH75dRdeYJKd4uuQiqch"
   },
   "resource": "projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
-  "timestamp": "2020-09-29T11:32:00.000Z"
+  "timestamp": "2020-09-29T11:32:00.123Z"
 }

--- a/events/generate/data/firestore_complex-legacy-output.json
+++ b/events/generate/data/firestore_complex-legacy-output.json
@@ -74,6 +74,6 @@
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
     "eventType": "providers/cloud.firestore/eventTypes/document.write",
     "resource": "projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
-    "timestamp": "2020-09-29T11:32:00.000Z"
+    "timestamp": "2020-09-29T11:32:00.123Z"
   }
 }

--- a/events/generate/data/firestore_simple-cloudevent-input.json
+++ b/events/generate/data/firestore_simple-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//firestore.googleapis.com/projects/project-id/databases/(default)",
   "subject": "documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "oldValue":{

--- a/events/generate/data/firestore_simple-cloudevent-output.json
+++ b/events/generate/data/firestore_simple-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//firestore.googleapis.com/projects/project-id/databases/(default)",
   "subject": "documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "oldValue":{

--- a/events/generate/data/firestore_simple-legacy-input.json
+++ b/events/generate/data/firestore_simple-legacy-input.json
@@ -47,5 +47,5 @@
       "doc":"2Vm2mI1d0wIaK2Waj5to"
    },
    "resource":"projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
-   "timestamp":"2020-09-29T11:32:00.000Z"
+   "timestamp":"2020-09-29T11:32:00.123Z"
 }

--- a/events/generate/data/firestore_simple-legacy-output.json
+++ b/events/generate/data/firestore_simple-legacy-output.json
@@ -42,6 +42,6 @@
      "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
      "eventType":"providers/cloud.firestore/eventTypes/document.write",
      "resource":"projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
-     "timestamp":"2020-09-29T11:32:00.000Z"
+     "timestamp":"2020-09-29T11:32:00.123Z"
    }
 }

--- a/events/generate/data/legacy_pubsub-cloudevent-input.json
+++ b/events/generate/data/legacy_pubsub-cloudevent-input.json
@@ -3,14 +3,14 @@
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "subscription": "projects/sample-project/subscriptions/sample-subscription",
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "attributes": {
         "attribute1": "value1"
       },

--- a/events/generate/data/legacy_pubsub-cloudevent-output.json
+++ b/events/generate/data/legacy_pubsub-cloudevent-output.json
@@ -3,13 +3,13 @@
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "attributes": {
         "attribute1": "value1"
       },

--- a/events/generate/data/legacy_pubsub-legacy-input.json
+++ b/events/generate/data/legacy_pubsub-legacy-input.json
@@ -1,6 +1,6 @@
 {
   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "timestamp": "2020-09-29T11:32:00.000Z",
+  "timestamp": "2020-09-29T11:32:00.123Z",
   "eventType": "providers/cloud.pubsub/eventTypes/topic.publish",
   "resource": "projects/sample-project/topics/gcf-test",
   "data": {

--- a/events/generate/data/legacy_pubsub-legacy-output-converted.json
+++ b/events/generate/data/legacy_pubsub-legacy-output-converted.json
@@ -1,7 +1,7 @@
 {
   "context": {
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType":"google.pubsub.topic.publish",
     "resource": {
       "service":"pubsub.googleapis.com",

--- a/events/generate/data/legacy_pubsub-legacy-output.json
+++ b/events/generate/data/legacy_pubsub-legacy-output.json
@@ -1,7 +1,7 @@
 {
   "context": {
     "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-    "timestamp": "2020-09-29T11:32:00.000Z",
+    "timestamp": "2020-09-29T11:32:00.123Z",
     "eventType": "providers/cloud.pubsub/eventTypes/topic.publish",
     "resource": "projects/sample-project/topics/gcf-test"
   },

--- a/events/generate/data/pubsub_binary-cloudevent-input.json
+++ b/events/generate/data/pubsub_binary-cloudevent-input.json
@@ -3,14 +3,14 @@
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "subscription": "projects/sample-project/subscriptions/sample-subscription",
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "data": "AQIDBA=="
     }
   }

--- a/events/generate/data/pubsub_binary-cloudevent-output.json
+++ b/events/generate/data/pubsub_binary-cloudevent-output.json
@@ -3,13 +3,13 @@
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "data": "AQIDBA=="
     }
   }

--- a/events/generate/data/pubsub_binary-legacy-input.json
+++ b/events/generate/data/pubsub_binary-legacy-input.json
@@ -1,7 +1,7 @@
 {
    "context": {
       "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp":"2020-09-29T11:32:00.000Z",
+      "timestamp":"2020-09-29T11:32:00.123Z",
       "eventType":"google.pubsub.topic.publish",
       "resource":{
         "service":"pubsub.googleapis.com",

--- a/events/generate/data/pubsub_binary-legacy-output.json
+++ b/events/generate/data/pubsub_binary-legacy-output.json
@@ -1,7 +1,7 @@
 {
    "context": {
       "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp":"2020-09-29T11:32:00.000Z",
+      "timestamp":"2020-09-29T11:32:00.123Z",
       "eventType":"google.pubsub.topic.publish",
       "resource":{
         "service":"pubsub.googleapis.com",

--- a/events/generate/data/pubsub_text-cloudevent-input.json
+++ b/events/generate/data/pubsub_text-cloudevent-input.json
@@ -3,14 +3,14 @@
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "subscription": "projects/sample-project/subscriptions/sample-subscription",
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "attributes": {
          "attr1":"attr1-value"
       },

--- a/events/generate/data/pubsub_text-cloudevent-output.json
+++ b/events/generate/data/pubsub_text-cloudevent-output.json
@@ -3,13 +3,13 @@
   "type": "google.cloud.pubsub.topic.v1.messagePublished",
   "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "message": {
       "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
       "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "publishTime": "2020-09-29T11:32:00.000Z",
+      "publishTime": "2020-09-29T11:32:00.123Z",
       "attributes": {
          "attr1":"attr1-value"
       },

--- a/events/generate/data/pubsub_text-legacy-input.json
+++ b/events/generate/data/pubsub_text-legacy-input.json
@@ -1,7 +1,7 @@
 {
    "context": {
       "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp":"2020-09-29T11:32:00.000Z",
+      "timestamp":"2020-09-29T11:32:00.123Z",
       "eventType":"google.pubsub.topic.publish",
       "resource":{
         "service":"pubsub.googleapis.com",

--- a/events/generate/data/pubsub_text-legacy-output.json
+++ b/events/generate/data/pubsub_text-legacy-output.json
@@ -1,7 +1,7 @@
 {
    "context": {
       "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp":"2020-09-29T11:32:00.000Z",
+      "timestamp":"2020-09-29T11:32:00.123Z",
       "eventType":"google.pubsub.topic.publish",
       "resource":{
         "service":"pubsub.googleapis.com",

--- a/events/generate/data/storage-cloudevent-input.json
+++ b/events/generate/data/storage-cloudevent-input.json
@@ -4,7 +4,7 @@
   "source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
   "subject": "objects/folder/Test.cs",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "bucket": "some-bucket",

--- a/events/generate/data/storage-cloudevent-output.json
+++ b/events/generate/data/storage-cloudevent-output.json
@@ -4,7 +4,7 @@
   "source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
   "subject": "objects/folder/Test.cs",
   "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-  "time": "2020-09-29T11:32:00.000Z",
+  "time": "2020-09-29T11:32:00.123Z",
   "datacontenttype": "application/json",
   "data": {
     "bucket": "some-bucket",

--- a/events/generate/data/storage-legacy-input.json
+++ b/events/generate/data/storage-legacy-input.json
@@ -1,7 +1,7 @@
 {
    "context": {
       "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp": "2020-09-29T11:32:00.000Z",
+      "timestamp": "2020-09-29T11:32:00.123Z",
       "eventType": "google.storage.object.finalize",
       "resource": {
          "service": "storage.googleapis.com",

--- a/events/generate/data/storage-legacy-output.json
+++ b/events/generate/data/storage-legacy-output.json
@@ -1,7 +1,7 @@
 {
    "context": {
       "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-      "timestamp": "2020-09-29T11:32:00.000Z",
+      "timestamp": "2020-09-29T11:32:00.123Z",
       "eventType": "google.storage.object.finalize",
       "resource": {
          "service": "storage.googleapis.com",


### PR DESCRIPTION
"2006-01-02T15:04:05.000Z" is not the correct format when using the
standard RFC3339 format, trailing zeros after the decimal are normally omitted. Only
when the decimal is non-zero is the data included in the string format.

This has caused problems with using the standard time libraries in
various languages to parse the test data because standard libraries
truncate the .000, but our tests data output expects it to still be
there in the output JSON.