### PR TITLE
feature: add ability to test concurrent requests

### DIFF
--- a/client/concurrency.go
+++ b/client/concurrency.go
@@ -40,7 +40,7 @@ func validateConcurrency(url string, functionType string) error {
 	switch functionType {
 	case "http":
 		sendFn = func() error {
-			return sendHTTP(url, []byte("hello"))
+			return sendHTTP(url, []byte(`{"data": "hello"}`))
 		}
 	case "cloudevent":
 		// Arbitrary payload that conforms to CloudEvent schema

--- a/client/concurrency.go
+++ b/client/concurrency.go
@@ -1,0 +1,172 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/functions-framework-conformance/events"
+)
+
+func timeExecution(fn func() error) (time.Duration, error) {
+	start := time.Now()
+	err := fn()
+	return time.Since(start), err
+}
+
+// validateConcurrency validates a server can handle concurrent requests by
+// valdating that the response time for a single request does not increase
+// linearly with n concurrent requests, given a function that:
+// 1. Is not CPU-bound (e.g. sleeps)
+// 2. Executes for at least 1s to ensure non-trivial measurement differences
+func validateConcurrency(url string, functionType string) error {
+	log.Printf("%s validation with concurrent requests...", functionType)
+	var sendFn func() error
+	switch functionType {
+	case "http":
+		sendFn = func() error {
+			return sendHTTP(url, []byte("hello"))
+		}
+	case "cloudevent":
+		// Arbitrary payload that conforms to CloudEvent schema
+		sendFn = func() error {
+			return send(url, events.CloudEvent, []byte(`{
+			"specversion": "1.0",
+			"type": "google.firebase.auth.user.v1.created",
+			"source": "//firebaseauth.googleapis.com/projects/my-project-id",
+			"subject": "users/UUpby3s4spZre6kHsgVSPetzQ8l2",
+			"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+			"time": "2020-09-29T11:32:00.123Z",
+			"datacontenttype": "application/json",
+			"data": {
+			  "email": "test@nowhere.com",
+			  "metadata": {
+				"createTime": "2020-05-26T10:42:27Z",
+				"lastSignInTime": "2020-10-24T11:00:00Z"
+			  },
+			  "providerData": [
+				{
+				  "email": "test@nowhere.com",
+				  "providerId": "password",
+				  "uid": "test@nowhere.com"
+				}
+			  ],
+			  "uid": "UUpby3s4spZre6kHsgVSPetzQ8l2"
+			}
+		  }`))
+		}
+	case "legacyevent":
+		// Arbitrary payload that conforms to Background event schema
+		sendFn = func() error {
+			return send(url, events.LegacyEvent, []byte(`{
+			"data": {
+			  "email": "test@nowhere.com",
+			  "metadata": {
+				"createdAt": "2020-05-26T10:42:27Z",
+				"lastSignedInAt": "2020-10-24T11:00:00Z"
+			  },
+			  "providerData": [
+				{
+				  "email": "test@nowhere.com",
+				  "providerId": "password",
+				  "uid": "test@nowhere.com"
+				}
+			  ],
+			  "uid": "UUpby3s4spZre6kHsgVSPetzQ8l2"
+			},
+			"eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+			"eventType": "providers/firebase.auth/eventTypes/user.create",
+			"notSupported": {
+			},
+			"resource": "projects/my-project-id",
+			"timestamp": "2020-09-29T11:32:00.123Z"
+		  }`))
+		}
+	default:
+		return fmt.Errorf("expected type to be one of 'http', 'cloudevent', or 'legacyevent', got %s", functionType)
+	}
+	if err := sendConcurrentRequests(sendFn); err != nil {
+		return err
+	}
+	log.Printf("Concurrency validation passed!")
+	return nil
+}
+
+func sendConcurrentRequests(sendFn func() error) error {
+	// Get a benchmark for the time it takes for a single request
+	singleReqTime, singleReqErr := timeExecution(func() error {
+		return sendFn()
+	})
+	if singleReqErr != nil {
+		return fmt.Errorf("concurrent validation unable to send single request to benchmark response time: %v", singleReqErr)
+	}
+
+	minWait := 1 * time.Second
+	if singleReqTime < minWait {
+		return fmt.Errorf("concurrent validation requires a function that waits at least %s before responding, function responded in %s", minWait, singleReqTime)
+	}
+	log.Printf("Single request response time benchmarked, took %s for 1 request", singleReqTime)
+
+	// Get a benchmark for the time it takes for concurrent requests
+	const numConReqs = 10
+	log.Printf("Starting %d concurrent workers to send requests", numConReqs)
+
+	type workerResponse struct {
+		id  int
+		err error
+	}
+	var wg sync.WaitGroup
+	respCh := make(chan workerResponse, numConReqs)
+	conReqTime, _ := timeExecution(func() error {
+		for i := 0; i < numConReqs; i++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+				err := sendFn()
+				respCh <- workerResponse{id: id, err: err}
+			}(i)
+		}
+
+		wg.Wait()
+		return nil
+	})
+
+	maybeErrMessage := ""
+	for i := 0; i < numConReqs; i++ {
+		resp := <-respCh
+		if resp.err != nil {
+			maybeErrMessage += fmt.Sprintf("error #%d: %v\n", i, resp.err)
+		} else {
+			log.Printf("Worker #%d done", resp.id)
+		}
+	}
+
+	if maybeErrMessage != "" {
+		return fmt.Errorf("at least one concurrent request failed:\n%s", maybeErrMessage)
+	}
+
+	// Validate that the concurrent requests were handled faster than if all
+	// the requests were handled serially, using the single request time
+	// as a benchmark. The concurrent time should be less than half of the
+	// time it would have taken to execute all requests serially.
+	if conReqTime*2 > numConReqs*singleReqTime {
+		return fmt.Errorf("function took too long to complete %d concurrent requests. %d concurrent request time: %s, single request time: %s", numConReqs, numConReqs, conReqTime, singleReqTime)
+	}
+	log.Printf("Concurrent request response time benchmarked, took %s for %d requests", conReqTime, numConReqs)
+	return nil
+}

--- a/client/main.go
+++ b/client/main.go
@@ -21,16 +21,17 @@ import (
 )
 
 var (
-	runCmd          = flag.String("cmd", "", "string with command to run a Functions Framework server at localhost:8080. Ignored if -buildpacks=true.")
-	functionType    = flag.String("type", "http", "type of function to validate (must be 'http', 'cloudevent', or 'legacyevent'")
-	validateMapping = flag.Bool("validate-mapping", true, "whether to validate mapping from legacy->cloud events and vice versa (as applicable)")
-	outputFile      = flag.String("output-file", "function_output.json", "name of file output by function")
-	useBuildpacks   = flag.Bool("buildpacks", true, "whether to use the current release of buildpacks to run the validation. If true, -cmd is ignored and --builder-* flags must be set.")
-	source          = flag.String("builder-source", "", "function source directory to use in building. Required if -buildpacks=true")
-	target          = flag.String("builder-target", "", "function target to use in building. Required if -buildpacks=true")
-	runtime         = flag.String("builder-runtime", "", "runtime to use in building. Required if -buildpacks=true")
-	tag             = flag.String("builder-tag", "latest", "builder image tag to use in building")
-	startDelay      = flag.Uint("start-delay", 1, "Seconds to wait before sending HTTP request to command process")
+	runCmd              = flag.String("cmd", "", "string with command to run a Functions Framework server at localhost:8080. Ignored if -buildpacks=true.")
+	functionType        = flag.String("type", "http", "type of function to validate (must be 'http', 'cloudevent', or 'legacyevent'")
+	validateMapping     = flag.Bool("validate-mapping", true, "whether to validate mapping from legacy->cloud events and vice versa (as applicable)")
+	outputFile          = flag.String("output-file", "function_output.json", "name of file output by function")
+	useBuildpacks       = flag.Bool("buildpacks", true, "whether to use the current release of buildpacks to run the validation. If true, -cmd is ignored and --builder-* flags must be set.")
+	source              = flag.String("builder-source", "", "function source directory to use in building. Required if -buildpacks=true")
+	target              = flag.String("builder-target", "", "function target to use in building. Required if -buildpacks=true")
+	runtime             = flag.String("builder-runtime", "", "runtime to use in building. Required if -buildpacks=true")
+	tag                 = flag.String("builder-tag", "latest", "builder image tag to use in building")
+	startDelay          = flag.Uint("start-delay", 1, "Seconds to wait before sending HTTP request to command process")
+	validateConcurrencyFlag = flag.Bool("validate-concurrency", false, "whether to validate concurrent requests can be handled, requires a function that sleeps for 1 second ")
 )
 
 func main() {
@@ -43,15 +44,16 @@ func main() {
 	}
 
 	v := newValidator(validatorParams{
-		validateMapping: *validateMapping,
-		useBuildpacks:   *useBuildpacks,
-		runCmd:          *runCmd,
-		outputFile:      *outputFile,
-		source:          *source,
-		target:          *target,
-		runtime:         *runtime,
-		functionType:    *functionType,
-		tag:             *tag,
+		validateMapping:     *validateMapping,
+		useBuildpacks:       *useBuildpacks,
+		runCmd:              *runCmd,
+		outputFile:          *outputFile,
+		source:              *source,
+		target:              *target,
+		runtime:             *runtime,
+		functionType:        *functionType,
+		tag:                 *tag,
+		validateConcurrency: *validateConcurrencyFlag,
 	})
 
 	if err := v.runValidation(); err != nil {


### PR DESCRIPTION
1. Example output:

```
FUNCTION_TARGET=concurrentCloudEvent client -buildpacks=false -type=cloudevent -cmd='go run testdata/conformance/cmd/declarative/main.go' -start-delay 5 -validate-concurrency=true
2022/01/20 10:52:28 Validating for cloudevent...
2022/01/20 10:52:28 Framework server started.
2022/01/20 10:52:33 cloudevent validation with concurrent requests...
2022/01/20 10:52:34 Single request response time benchmarked, took 1.003920604s for 1 request
2022/01/20 10:52:34 Starting 10 concurrent workers to send requests
2022/01/20 10:52:35 Worker #4 done
2022/01/20 10:52:35 Worker #2 done
2022/01/20 10:52:35 Worker #6 done
2022/01/20 10:52:35 Worker #1 done
2022/01/20 10:52:35 Worker #5 done
2022/01/20 10:52:35 Worker #9 done
2022/01/20 10:52:35 Worker #8 done
2022/01/20 10:52:35 Worker #0 done
2022/01/20 10:52:35 Worker #7 done
2022/01/20 10:52:35 Worker #3 done
2022/01/20 10:52:35 Concurrent request response time benchmarked, took 1.004998324s for 10 requests
2022/01/20 10:52:35 Concurrency validation passed!
2022/01/20 10:52:35 Framework server shut down. Wrote logs to /tmp/serverlog_stdout.txt and /tmp/serverlog_stderr.txt.
2022/01/20 10:52:35 All validation passed!
```