### PR TITLE
feat: Add new GitHub Action for installing client

### DIFF
--- a/.github/actions/client/install/action.yml
+++ b/.github/actions/client/install/action.yml
@@ -1,0 +1,24 @@
+name: 'Install Conformance Test Client'
+description: 'Install and caches the Functions Framework conformance test client'
+inputs:
+  client-version:
+    description: 'Conformance tests client version'
+    default: 'latest'
+  cache-key:
+    description: 'Cache key for storing client'
+    default: conformance-client-latest
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.x
+    - name: Install client
+      run: go install github.com/GoogleCloudPlatform/functions-framework-conformance/client@${{ inputs.client-version }}
+      shell: bash
+    - name: Cache client
+      uses: actions/cache@v3
+      with:
+        path: ~/go/bin/client
+        key: ${{ inputs.cache-key }}


### PR DESCRIPTION
This decomposes the existing conformance test action into two steps:
download and run

This allows:
- caching of the client within a Workflow and between Workflow runs
- setup-go action to be skipped since it is now part of "download"
- removal of TypeScript action because the "run" logic is now trivial

Calling GitHub Workflows can now trivially run the client in one line
with the normal flags (e.g. 'client -buildpacks=false -type=http
-cmd='go run testdata/conformance/cmd/http/main.go' -start-delay 5
-validate-mapping=true') instead of calling a GitHub action with unique
syntax for input flags that are disjoint from running locally.