### PR TITLE
feat: Add reusable Workflow for buildpack integration test

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -1,0 +1,141 @@
+name: Buildpack Integration Test
+on:
+  workflow_call:
+    inputs:
+      http-builder-source:
+        description: HTTP function source; relative to repo root
+        type: string
+        required: true
+      http-builder-target:
+        description: HTTP function target
+        type: string
+        required: true
+      cloudevent-builder-source:
+        description: CloudEvent function source; relative to repo root
+        type: string
+        required: true
+      cloudevent-builder-target:
+        description: CloudEvent function target
+        type: string
+        required: true
+      builder-runtime:
+        description: GCF runtime (e.g. 'go116')
+        type: string
+        required: true
+      event-builder-source:
+        description: Background function source; relative to repo root
+        type: string
+        required: false
+      event-builder-target:
+        description: Background function target
+        type: string
+        required: false
+      builder-tag:
+        description: GCF builder image tag
+        type: string
+        default: 'latest'
+        required: false
+      conformance-client-version:
+        # Can be used to pin to older conformance test standards while
+        # developing a Functions Framework
+        description: Conformance test client version
+        type: string
+        default: 'latest'
+        required: false
+      conformance-action-version:
+        # Can be used to pin to older conformance GitHub Actions if there are
+        # breaking changes
+        description: Conformance GitHub Actions version by git ref
+        type: string
+        default: 'master'
+        required: false
+jobs:
+  # Download and cache the Functions Framework conformance test client
+  download-conformance-client:
+    runs-on: ubuntu-latest
+    outputs:
+      # Pass the conformance client version key to the next job
+      # so the client can be retrieved from the GitHub cache.
+      cache-key: ${{ steps.set-cached-client-version.outputs.key }}
+    steps:
+      # Checkout the conformance repo at the specified branch and refer to the
+      # included GitHub Actions by local path. This effectively "versions"
+      # this Workflow by enforcing the the Actions and Workflow are at the
+      # same commit.
+      - name: Checkout functions-framework-conformance
+        uses: actions/checkout@v3
+        with:
+          repository: 'GoogleCloudPlatform/functions-framework-conformance'
+          ref: ${{ inputs.conformance-action-version }}
+
+      # RESOLVE CONFORMANCE CLIENT VERSION
+      - name: Set conformance test client version from Workflow input
+        run: echo CLIENT_VERSION=${{ inputs.conformance-client-version }} >> $GITHUB_ENV
+      - name: Resolve latest conformance test client version
+        if: ${{ inputs.conformance-client-version == 'latest' }}
+        id: conformance-client-latest
+        uses: ./actions/client/resolve-latest
+      - name: Set conformance test client version from latest
+        if: ${{ inputs.conformance-client-version == 'latest' }}
+        run: echo CLIENT_VERSION=${{ steps.conformance-client-latest.outputs.version }} >> $GITHUB_ENV
+      - name: Set cache key for client version
+        id: set-cached-client-version
+        run: echo "::set-output name=key::conformance-client-${{ env.CLIENT_VERSION }}"
+
+      # INSTALL CONFORMANCE CLIENT
+      - name: Check for cached conformance test client
+        id: check-for-cached-client
+        uses: actions/cache@v3
+        with:
+          path: ~/go/bin/client
+          key: ${{ steps.set-cached-client-version.outputs.key }}
+      # Cache miss, need to download conformance test client using Go tooling
+      - name: Download conformance test client
+        if: ${{ steps.check-for-cached-client.outputs.cache-hit != 'true' }}
+        uses: ./actions/client/install
+        with:
+          client-version: ${{ env.CLIENT_VERSION }}
+          cache-key: ${{ steps.set-cached-client-version.outputs.key }}
+
+  run-buildpack-integration-test:
+    needs:
+      - download-conformance-client
+    runs-on: ubuntu-latest
+    # Run tests in parallel on different GitHub runners
+    strategy:
+      matrix:
+        type: [http, cloudevent, event]
+        include:
+          - type: http
+            builder-source: ${{ inputs.http-builder-source }}
+            builder-target: ${{ inputs.http-builder-target }}
+          - type: cloudevent
+            builder-source: ${{ inputs.cloudevent-builder-source }}
+            builder-target: ${{ inputs.cloudevent-builder-target }}
+          - type: event
+            builder-source: ${{ inputs.event-builder-source }}
+            builder-target: ${{ inputs.event-builder-target }}
+    steps:
+      # if-condition on each step will effectively skip optional tests
+      - name: Retrieve conformance client
+        if: ${{ matrix.builder-source }}
+        uses: actions/cache@v3
+        with:
+          path: ~/go/bin/client
+          key: ${{ needs.download-conformance-client.outputs.cache-key }}
+      - name: Add client to PATH
+        if: ${{ matrix.builder-source }}
+        run: echo "$HOME/go/bin" >> $GITHUB_PATH
+      - name: Check out repository
+        if: ${{ matrix.builder-source }}
+        uses: actions/checkout@v3
+      - name: Buildpack integration test
+        if: ${{ matrix.builder-source }}
+        run: |
+          client \
+          -type=${{ matrix.type }} \
+          -builder-source=${{ matrix.builder-source }} \
+          -builder-target=${{ matrix.builder-target }} \
+          -builder-runtime=${{ inputs.builder-runtime }} \
+          -builder-tag=${{ inputs.builder-tag }} \
+          -validate-mapping=false


### PR DESCRIPTION
This can be used by Functions Frameworks to test the framework against
the official GCF builders, ensuring the frameworks will work containerized.

It runs HTTP tests similar to the local conformance test client runs, except in buildpack mode which:
1. Builds the function into a container using `pack` and the appropriate GCF builder
2. Runs the container on docker
3. Sends standard conformance test HTTP requests to the running container and verifies the response

Optimizations:
- Conformance test client is cached by client version, so it doesn't have to be rebuilt/re-installed unless there's a new release
- Each conformance test client run is run in its own GitHub job/runner in parallel

Example `.github/workflows/buildpack-integration-test.yml` that would go in an FF repo:
```yaml
name: Buildpack Integration Test
on:
  # manually triggered for example
  workflow_dispatch:
jobs:
  buildpack-integration-test:
    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v2.0.0
    with:
      http-builder-source: 'testdata/conformance/function'
      http-builder-target: 'declarativeHTTP'
      cloudevent-builder-source: 'testdata/conformance/function'
      cloudevent-builder-target: 'declarativeCloudEvent'
      builder-runtime: 'go116'
      builder-tag: 'go116_20220320_1_16_13_RC00'
```