### PR TITLE
feat: add prerun hook to buildpack integration test

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -30,6 +30,10 @@ on:
         description: Background function target
         type: string
         required: false
+      prerun:
+        description: Bash script to run before test; relative to repo root
+        type: string
+        required: false
       builder-tag:
         description: GCF builder image tag
         type: string
@@ -129,6 +133,9 @@ jobs:
       - name: Check out repository
         if: ${{ matrix.builder-source }}
         uses: actions/checkout@v3
+      - name: Prerun script
+        if: ${{ matrix.builder-source && inputs.prerun }}
+        run: bash -x ${{ inputs.prerun }}
       - name: Buildpack integration test
         if: ${{ matrix.builder-source }}
         run: |


### PR DESCRIPTION
This gives the various FF repos the chance to execute bash commands to
setup the test function to use the GitHub commit under test  before running the buildpack test.

Example config for FF Go repo:
```yaml
  go113-buildpack-test:
    uses: GoogleCloudPlatofrm/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.4.0
    with:
      http-builder-source: 'testdata/conformance/function'
      http-builder-target: 'declarativeHTTP'
      cloudevent-builder-source: 'testdata/conformance/function'
      cloudevent-builder-target: 'declarativeCloudEvent'
      prerun: 'testdata/conformance/function/prerun.sh ${{ github.sha }}' # prerun.sh uses the github.sha to modify go.mod file
      builder-runtime: 'go113'
      builder-tag: 'go113_20220320_1_13_15_RC00'
```