### PR TITLE
feat: add runtimes matrix to buildpack integration test workflow

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -18,8 +18,8 @@ on:
         description: CloudEvent function target
         type: string
         required: true
-      builder-runtime:
-        description: GCF runtime (e.g. 'go116')
+      builder-runtimes:
+        description: JSON array of GCF runtimes to test (e.g. '["go113", "go116"]')
         type: string
         required: true
       event-builder-source:
@@ -35,7 +35,7 @@ on:
         type: string
         required: false
       builder-tag:
-        description: GCF builder image tag
+        description: GCF builder image tag; the image tag must exist for each of the builder versions specified in the `builder-runtimes` field
         type: string
         default: 'latest'
         required: false
@@ -101,7 +101,7 @@ jobs:
           client-version: ${{ env.CLIENT_VERSION }}
           cache-key: ${{ steps.set-cached-client-version.outputs.key }}
 
-  run-buildpack-integration-test:
+  test:
     needs:
       - download-conformance-client
     runs-on: ubuntu-latest
@@ -109,6 +109,7 @@ jobs:
     strategy:
       matrix:
         type: [http, cloudevent, event]
+        builder-runtime: ${{ fromJSON(inputs.builder-runtimes) }}
         include:
           - type: http
             builder-source: ${{ inputs.http-builder-source }}
@@ -143,6 +144,6 @@ jobs:
           -type=${{ matrix.type }} \
           -builder-source=${{ matrix.builder-source }} \
           -builder-target=${{ matrix.builder-target }} \
-          -builder-runtime=${{ inputs.builder-runtime }} \
+          -builder-runtime=${{ matrix.builder-runtime }} \
           -builder-tag=${{ inputs.builder-tag }} \
           -validate-mapping=false

--- a/client/buildpacks.go
+++ b/client/buildpacks.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	image             = "conformance-test-func"
-	builderURL        = "us.gcr.io/fn-img/buildpacks/%s/builder:%s"
+	builderURL        = "gcr.io/gae-runtimes/buildpacks/%s/builder:%s"
 	gcfTargetPlatform = "gcf"
 )
 


### PR DESCRIPTION
This allows calling FF repos to specify only one GitHub Job that tests
multiple runtime version using workflow matrices handled by buildpack
integration test workflow.

Previously, only one runtime could be tested
per GitHub Job, which required copy-pasting the entire Workflow
configuration multiple times into different GitHub Jobs.

Example usage:
```
name: Buildpack Integration Test
on:
  push:
    branches:
      - master
  workflow_dispatch:
jobs:
  buildpack-test:
    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@1.4.2
    with:
      http-builder-source: 'testdata/conformance/function'
      http-builder-target: 'declarativeHTTP'
      cloudevent-builder-source: 'testdata/conformance/function'
      cloudevent-builder-target: 'declarativeCloudEvent'
      prerun: 'testdata/conformance/function/prerun.sh ${{ github.sha }}'
      builder-runtimes: '["go113", "go116"]'
```

By default, the latest builder for a runtime will be used by finding
the `latest` image tag. If only one runtime is being tested with the
GitHub job, then a specific builder version can still be specified by
builder tag.

```
jobs:
  go113-buildpack-test:
    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@latestTag
    with:
      http-builder-source: 'testdata/conformance/function'
      http-builder-target: 'declarativeHTTP'
      cloudevent-builder-source: 'testdata/conformance/function'
      cloudevent-builder-target: 'declarativeCloudEvent'
      prerun: 'testdata/conformance/function/prerun.sh ${{ github.sha }}'
      builder-runtimes: '["go113"]'
      builder-tag: 'go113_20220320_1_13_15_RC00'
```