### PR TITLE
fix: add default output-file workflow value

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -43,6 +43,7 @@ on:
         description: The output file conformance test files should write to for verification; relative to the source code directory
         type: string
         required: false
+        default: 'function_output.json'
       builder-tag:
         description: GCF builder image tag
         type: string


### PR DESCRIPTION
Match the default value used by the conformance test client. The flag is
always passed through by the buildpack integration test workflow, so
this ensures it's not empty string by default.