### PR TITLE
feat: Add a parameter to consume additional runtime variables for docker run

### DIFF
--- a/client/buildpacks.go
+++ b/client/buildpacks.go
@@ -126,17 +126,20 @@ func (b *buildpacksFunctionServer) run() (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-
+	var temp = b.envs.String()
+	log.Printf("Extra variable s%se",temp)
 	args := []string{"docker", "run",
 		"--network=host",
 		// TODO: figure out why these aren't getting set in the buildpack.
 		"--env=FUNCTION_TARGET=" + b.target,
 		"--env=FUNCTION_SIGNATURE_TYPE=" + b.funcType,
-		b.envs.String(),
-		image,
 	}
+	if len(*b.envs) != 0 {
+		args = append(args, *b.envs...)
+	}
+	args = append(args, image)
+	log.Printf("Docker command #%s",args)
 	cmd := exec.Command(args[0], args[1:]...)
-
 	err = cmd.Start()
 
 	// TODO: figure out why this isn't picking up errors.

--- a/client/buildpacks.go
+++ b/client/buildpacks.go
@@ -47,7 +47,7 @@ type buildpacksFunctionServer struct {
 	logStderr          *os.File
 	stdoutFile         string
 	stderrFile         string
-	functionConcurrency	   uint
+	envs	   *envars
 }
 
 func (b *buildpacksFunctionServer) Start(stdoutFile, stderrFile, functionOutputFile string) (func(), error) {
@@ -132,9 +132,10 @@ func (b *buildpacksFunctionServer) run() (func(), error) {
 		// TODO: figure out why these aren't getting set in the buildpack.
 		"--env=FUNCTION_TARGET=" + b.target,
 		"--env=FUNCTION_SIGNATURE_TYPE=" + b.funcType,
-		"--env=FUNCTION_CONCURRENCY=" + fmt.Sprintf("%d", b.functionConcurrency),
+		b.envs.String(),
 		image,
 	}
+	log.Printf("docker command: #%s", args)
 	cmd := exec.Command(args[0], args[1:]...)
 
 	err = cmd.Start()

--- a/client/buildpacks.go
+++ b/client/buildpacks.go
@@ -126,7 +126,7 @@ func (b *buildpacksFunctionServer) run() (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	args := []string{"docker", "run",
 		"--network=host",
 		// TODO: figure out why these aren't getting set in the buildpack.

--- a/client/buildpacks.go
+++ b/client/buildpacks.go
@@ -135,7 +135,6 @@ func (b *buildpacksFunctionServer) run() (func(), error) {
 		b.envs.String(),
 		image,
 	}
-	log.Printf("docker command: #%s", args)
 	cmd := exec.Command(args[0], args[1:]...)
 
 	err = cmd.Start()

--- a/client/buildpacks.go
+++ b/client/buildpacks.go
@@ -48,7 +48,7 @@ type buildpacksFunctionServer struct {
 	logStderr          *os.File
 	stdoutFile         string
 	stderrFile         string
-	envs	   		   string
+	envs               string
 }
 
 func (b *buildpacksFunctionServer) Start(stdoutFile, stderrFile, functionOutputFile string) (func(), error) {

--- a/client/buildpacks.go
+++ b/client/buildpacks.go
@@ -158,6 +158,7 @@ func (b *buildpacksFunctionServer) run() (func(), error) {
 func (b *buildpacksFunctionServer) getRuntimeVars() []string {
 	var variables = strings.Split(b.envs, ",")
 	runtimeVars := []string {"run",
+	"--network=host",
 	// TODO: figure out why these aren't getting set in the buildpack.
 	"--env=FUNCTION_TARGET=" + b.target,
 	"--env=FUNCTION_SIGNATURE_TYPE=" + b.funcType,}

--- a/client/buildpacks.go
+++ b/client/buildpacks.go
@@ -47,6 +47,7 @@ type buildpacksFunctionServer struct {
 	logStderr          *os.File
 	stdoutFile         string
 	stderrFile         string
+	functionConcurrency	   uint
 }
 
 func (b *buildpacksFunctionServer) Start(stdoutFile, stderrFile, functionOutputFile string) (func(), error) {
@@ -125,12 +126,13 @@ func (b *buildpacksFunctionServer) run() (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-
+	
 	args := []string{"docker", "run",
 		"--network=host",
 		// TODO: figure out why these aren't getting set in the buildpack.
 		"--env=FUNCTION_TARGET=" + b.target,
 		"--env=FUNCTION_SIGNATURE_TYPE=" + b.funcType,
+		"--env=FUNCTION_CONCURRENCY=" + fmt.Sprintf("%d", b.functionConcurrency),
 		image,
 	}
 	cmd := exec.Command(args[0], args[1:]...)

--- a/client/local.go
+++ b/client/local.go
@@ -49,7 +49,7 @@ func (l *localFunctionServer) Start(stdoutFile, stderrFile, functionOutputFile s
 	}
 	cmd.Stderr = stderr
 	cmd.Env = os.Environ()
-	for _,s := range l.envs{
+	for _, s := range l.envs {
 		if s != "" {
 			cmd.Env = append(cmd.Env, s)
 		}

--- a/client/local.go
+++ b/client/local.go
@@ -27,7 +27,7 @@ type localFunctionServer struct {
 	cmd                string
 	stdoutFile         string
 	stderrFile         string
-	envs               string
+	envs               []string
 }
 
 func (l *localFunctionServer) Start(stdoutFile, stderrFile, functionOutputFile string) (func(), error) {
@@ -49,8 +49,7 @@ func (l *localFunctionServer) Start(stdoutFile, stderrFile, functionOutputFile s
 	}
 	cmd.Stderr = stderr
 	cmd.Env = os.Environ()
-	var variables = strings.Split(l.envs,",")
-	for _,s := range variables{
+	for _,s := range l.envs{
 		if s != "" {
 			cmd.Env = append(cmd.Env, s)
 		}

--- a/client/local.go
+++ b/client/local.go
@@ -27,7 +27,7 @@ type localFunctionServer struct {
 	cmd                string
 	stdoutFile         string
 	stderrFile         string
-	envs			   string
+	envs               string
 }
 
 func (l *localFunctionServer) Start(stdoutFile, stderrFile, functionOutputFile string) (func(), error) {

--- a/client/local.go
+++ b/client/local.go
@@ -27,6 +27,7 @@ type localFunctionServer struct {
 	cmd                string
 	stdoutFile         string
 	stderrFile         string
+	envs			   string
 }
 
 func (l *localFunctionServer) Start(stdoutFile, stderrFile, functionOutputFile string) (func(), error) {
@@ -47,6 +48,13 @@ func (l *localFunctionServer) Start(stdoutFile, stderrFile, functionOutputFile s
 		return nil, err
 	}
 	cmd.Stderr = stderr
+	cmd.Env = os.Environ()
+	var variables = strings.Split(l.envs,",")
+	for _,s := range variables{
+		if s != "" {
+			cmd.Env = append(cmd.Env, s)
+		}
+	}
 	err = cmd.Start()
 	if err != nil {
 		return nil, err

--- a/client/main.go
+++ b/client/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"flag"
 	"log"
+	"strings"
 )
 
 var (
@@ -55,7 +56,7 @@ func main() {
 		functionType:        *functionType,
 		tag:                 *tag,
 		validateConcurrency: *validateConcurrencyFlag,
-		envs: *envs,
+		envs: strings.Split(*envs,","),
 	})
 
 	if err := v.runValidation(); err != nil {

--- a/client/main.go
+++ b/client/main.go
@@ -33,7 +33,7 @@ var (
 	startDelay          = flag.Uint("start-delay", 1, "Seconds to wait before sending HTTP request to command process")
 	validateConcurrencyFlag = flag.Bool("validate-concurrency", false, "whether to validate concurrent requests can be handled, requires a function that sleeps for 1 second ")
 	functionConcurrency = flag.Uint("function-concurrency", 10, "Max concurrent requests handled per instance")
-	)
+)
 
 func main() {
 	flag.Parse()

--- a/client/main.go
+++ b/client/main.go
@@ -18,19 +18,7 @@ package main
 import (
 	"flag"
 	"log"
-	"fmt"
-	"strings"
 )
-type envars []string
-func (i *envars) String() string {
-	return strings.Join(*i," ")
-}
-
-func (i *envars) Set(value string) error {
-	*i = append(*i, fmt.Sprintf("--env=%s",value))
-	return nil
-}
-var runtimeVars envars
 
 var (
 	runCmd              = flag.String("cmd", "", "string with command to run a Functions Framework server at localhost:8080. Ignored if -buildpacks=true.")
@@ -44,10 +32,10 @@ var (
 	tag                 = flag.String("builder-tag", "latest", "builder image tag to use in building")
 	startDelay          = flag.Uint("start-delay", 1, "Seconds to wait before sending HTTP request to command process")
 	validateConcurrencyFlag = flag.Bool("validate-concurrency", false, "whether to validate concurrent requests can be handled, requires a function that sleeps for 1 second ")
+	envs 				= flag.String("envs", "", "a comma separated string of additional runtime environment variables")
 )
 
 func main() {
-	flag.Var(&runtimeVars, "envs", "Runtime environment variables")
 	flag.Parse()
 
 	if *useBuildpacks {
@@ -67,7 +55,7 @@ func main() {
 		functionType:        *functionType,
 		tag:                 *tag,
 		validateConcurrency: *validateConcurrencyFlag,
-		envs: &runtimeVars,
+		envs: *envs,
 	})
 
 	if err := v.runValidation(); err != nil {

--- a/client/main.go
+++ b/client/main.go
@@ -18,7 +18,22 @@ package main
 import (
 	"flag"
 	"log"
+	"fmt"
 )
+type envars []string
+func (i *envars) String() string {
+	var runtimeVars=""
+	for _,s :=range *i  {
+		runtimeVars = fmt.Sprintf("%s --env=%s",runtimeVars,s)
+	}
+	return runtimeVars
+}
+
+func (i *envars) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+var runtimeVars envars
 
 var (
 	runCmd              = flag.String("cmd", "", "string with command to run a Functions Framework server at localhost:8080. Ignored if -buildpacks=true.")
@@ -32,10 +47,10 @@ var (
 	tag                 = flag.String("builder-tag", "latest", "builder image tag to use in building")
 	startDelay          = flag.Uint("start-delay", 1, "Seconds to wait before sending HTTP request to command process")
 	validateConcurrencyFlag = flag.Bool("validate-concurrency", false, "whether to validate concurrent requests can be handled, requires a function that sleeps for 1 second ")
-	functionConcurrency = flag.Uint("function-concurrency", 10, "Max concurrent requests handled per instance")
 )
 
 func main() {
+	flag.Var(&runtimeVars, "envs", "Runtime environment variables")
 	flag.Parse()
 
 	if *useBuildpacks {
@@ -55,7 +70,7 @@ func main() {
 		functionType:        *functionType,
 		tag:                 *tag,
 		validateConcurrency: *validateConcurrencyFlag,
-		functionConcurrency: *functionConcurrency,
+		envs: &runtimeVars,
 	})
 
 	if err := v.runValidation(); err != nil {

--- a/client/main.go
+++ b/client/main.go
@@ -22,18 +22,18 @@ import (
 )
 
 var (
-	runCmd              = flag.String("cmd", "", "string with command to run a Functions Framework server at localhost:8080. Ignored if -buildpacks=true.")
-	functionType        = flag.String("type", "http", "type of function to validate (must be 'http', 'cloudevent', or 'legacyevent'")
-	validateMapping     = flag.Bool("validate-mapping", true, "whether to validate mapping from legacy->cloud events and vice versa (as applicable)")
-	outputFile          = flag.String("output-file", "function_output.json", "name of file output by function")
-	useBuildpacks       = flag.Bool("buildpacks", true, "whether to use the current release of buildpacks to run the validation. If true, -cmd is ignored and --builder-* flags must be set.")
-	source              = flag.String("builder-source", "", "function source directory to use in building. Required if -buildpacks=true")
-	target              = flag.String("builder-target", "", "function target to use in building. Required if -buildpacks=true")
-	runtime             = flag.String("builder-runtime", "", "runtime to use in building. Required if -buildpacks=true")
-	tag                 = flag.String("builder-tag", "latest", "builder image tag to use in building")
-	startDelay          = flag.Uint("start-delay", 1, "Seconds to wait before sending HTTP request to command process")
+	runCmd                  = flag.String("cmd", "", "string with command to run a Functions Framework server at localhost:8080. Ignored if -buildpacks=true.")
+	functionType            = flag.String("type", "http", "type of function to validate (must be 'http', 'cloudevent', or 'legacyevent'")
+	validateMapping         = flag.Bool("validate-mapping", true, "whether to validate mapping from legacy->cloud events and vice versa (as applicable)")
+	outputFile              = flag.String("output-file", "function_output.json", "name of file output by function")
+	useBuildpacks           = flag.Bool("buildpacks", true, "whether to use the current release of buildpacks to run the validation. If true, -cmd is ignored and --builder-* flags must be set.")
+	source                  = flag.String("builder-source", "", "function source directory to use in building. Required if -buildpacks=true")
+	target                  = flag.String("builder-target", "", "function target to use in building. Required if -buildpacks=true")
+	runtime                 = flag.String("builder-runtime", "", "runtime to use in building. Required if -buildpacks=true")
+	tag                     = flag.String("builder-tag", "latest", "builder image tag to use in building")
+	startDelay              = flag.Uint("start-delay", 1, "Seconds to wait before sending HTTP request to command process")
 	validateConcurrencyFlag = flag.Bool("validate-concurrency", false, "whether to validate concurrent requests can be handled, requires a function that sleeps for 1 second ")
-	envs                = flag.String("envs", "", "a comma separated string of additional runtime environment variables")
+	envs                    = flag.String("envs", "", "a comma separated string of additional runtime environment variables")
 )
 
 func main() {
@@ -56,7 +56,7 @@ func main() {
 		functionType:        *functionType,
 		tag:                 *tag,
 		validateConcurrency: *validateConcurrencyFlag,
-		envs: strings.Split(*envs,","),
+		envs:                strings.Split(*envs, ","),
 	})
 
 	if err := v.runValidation(); err != nil {

--- a/client/main.go
+++ b/client/main.go
@@ -19,18 +19,15 @@ import (
 	"flag"
 	"log"
 	"fmt"
+	"strings"
 )
 type envars []string
 func (i *envars) String() string {
-	var runtimeVars=""
-	for _,s :=range *i  {
-		runtimeVars = fmt.Sprintf("%s --env=%s",runtimeVars,s)
-	}
-	return runtimeVars
+	return strings.Join(*i," ")
 }
 
 func (i *envars) Set(value string) error {
-	*i = append(*i, value)
+	*i = append(*i, fmt.Sprintf("--env=%s",value))
 	return nil
 }
 var runtimeVars envars

--- a/client/main.go
+++ b/client/main.go
@@ -32,7 +32,8 @@ var (
 	tag                 = flag.String("builder-tag", "latest", "builder image tag to use in building")
 	startDelay          = flag.Uint("start-delay", 1, "Seconds to wait before sending HTTP request to command process")
 	validateConcurrencyFlag = flag.Bool("validate-concurrency", false, "whether to validate concurrent requests can be handled, requires a function that sleeps for 1 second ")
-)
+	functionConcurrency = flag.Uint("function-concurrency", 10, "Max concurrent requests handled per instance")
+	)
 
 func main() {
 	flag.Parse()
@@ -54,6 +55,7 @@ func main() {
 		functionType:        *functionType,
 		tag:                 *tag,
 		validateConcurrency: *validateConcurrencyFlag,
+		functionConcurrency: *functionConcurrency,
 	})
 
 	if err := v.runValidation(); err != nil {

--- a/client/main.go
+++ b/client/main.go
@@ -32,7 +32,7 @@ var (
 	tag                 = flag.String("builder-tag", "latest", "builder image tag to use in building")
 	startDelay          = flag.Uint("start-delay", 1, "Seconds to wait before sending HTTP request to command process")
 	validateConcurrencyFlag = flag.Bool("validate-concurrency", false, "whether to validate concurrent requests can be handled, requires a function that sleeps for 1 second ")
-	envs 				= flag.String("envs", "", "a comma separated string of additional runtime environment variables")
+	envs                = flag.String("envs", "", "a comma separated string of additional runtime environment variables")
 )
 
 func main() {

--- a/client/validate.go
+++ b/client/validate.go
@@ -35,6 +35,7 @@ type validatorParams struct {
 	tag                 string
 	functionType        string
 	validateConcurrency bool
+	functionConcurrency uint
 }
 
 type validator struct {
@@ -45,6 +46,7 @@ type validator struct {
 	functionOutputFile  string
 	stdoutFile          string
 	stderrFile          string
+	functionConcurrency uint
 }
 
 func newValidator(params validatorParams) *validator {
@@ -55,6 +57,7 @@ func newValidator(params validatorParams) *validator {
 		functionOutputFile:  params.outputFile,
 		stdoutFile:          defaultStdoutFile,
 		stderrFile:          defaultStderrFile,
+		functionConcurrency: params.functionConcurrency,
 	}
 
 	if !params.useBuildpacks {
@@ -74,6 +77,7 @@ func newValidator(params validatorParams) *validator {
 		runtime:  params.runtime,
 		tag:      params.tag,
 		funcType: params.functionType,
+		functionConcurrency: params.functionConcurrency,
 	}
 	return &v
 }

--- a/client/validate.go
+++ b/client/validate.go
@@ -60,7 +60,7 @@ func newValidator(params validatorParams) *validator {
 
 	if !params.useBuildpacks {
 		v.funcServer = &localFunctionServer{
-			cmd: params.runCmd,
+			cmd:  params.runCmd,
 			envs: params.envs,
 		}
 		return &v
@@ -76,7 +76,7 @@ func newValidator(params validatorParams) *validator {
 		runtime:  params.runtime,
 		tag:      params.tag,
 		funcType: params.functionType,
-		envs: params.envs,
+		envs:     params.envs,
 	}
 	return &v
 }

--- a/client/validate.go
+++ b/client/validate.go
@@ -35,7 +35,7 @@ type validatorParams struct {
 	tag                 string
 	functionType        string
 	validateConcurrency bool
-	envs 				string
+	envs                string
 }
 
 type validator struct {
@@ -46,7 +46,7 @@ type validator struct {
 	functionOutputFile  string
 	stdoutFile          string
 	stderrFile          string
-	envs 				string
+	envs                string
 }
 
 func newValidator(params validatorParams) *validator {

--- a/client/validate.go
+++ b/client/validate.go
@@ -35,7 +35,7 @@ type validatorParams struct {
 	tag                 string
 	functionType        string
 	validateConcurrency bool
-	functionConcurrency uint
+	envs *envars
 }
 
 type validator struct {
@@ -46,7 +46,7 @@ type validator struct {
 	functionOutputFile  string
 	stdoutFile          string
 	stderrFile          string
-	functionConcurrency uint
+	envs *envars
 }
 
 func newValidator(params validatorParams) *validator {
@@ -57,7 +57,7 @@ func newValidator(params validatorParams) *validator {
 		functionOutputFile:  params.outputFile,
 		stdoutFile:          defaultStdoutFile,
 		stderrFile:          defaultStderrFile,
-		functionConcurrency: params.functionConcurrency,
+		envs: params.envs,
 	}
 
 	if !params.useBuildpacks {
@@ -77,7 +77,7 @@ func newValidator(params validatorParams) *validator {
 		runtime:  params.runtime,
 		tag:      params.tag,
 		funcType: params.functionType,
-		functionConcurrency: params.functionConcurrency,
+		envs: params.envs,
 	}
 	return &v
 }

--- a/client/validate.go
+++ b/client/validate.go
@@ -35,7 +35,7 @@ type validatorParams struct {
 	tag                 string
 	functionType        string
 	validateConcurrency bool
-	envs                string
+	envs                []string
 }
 
 type validator struct {
@@ -46,7 +46,6 @@ type validator struct {
 	functionOutputFile  string
 	stdoutFile          string
 	stderrFile          string
-	envs                string
 }
 
 func newValidator(params validatorParams) *validator {
@@ -57,7 +56,6 @@ func newValidator(params validatorParams) *validator {
 		functionOutputFile:  params.outputFile,
 		stdoutFile:          defaultStdoutFile,
 		stderrFile:          defaultStderrFile,
-		envs: params.envs,
 	}
 
 	if !params.useBuildpacks {

--- a/client/validate.go
+++ b/client/validate.go
@@ -35,7 +35,7 @@ type validatorParams struct {
 	tag                 string
 	functionType        string
 	validateConcurrency bool
-	envs *envars
+	envs 				string
 }
 
 type validator struct {
@@ -46,7 +46,7 @@ type validator struct {
 	functionOutputFile  string
 	stdoutFile          string
 	stderrFile          string
-	envs *envars
+	envs 				string
 }
 
 func newValidator(params validatorParams) *validator {
@@ -63,6 +63,7 @@ func newValidator(params validatorParams) *validator {
 	if !params.useBuildpacks {
 		v.funcServer = &localFunctionServer{
 			cmd: params.runCmd,
+			envs: params.envs,
 		}
 		return &v
 	}


### PR DESCRIPTION
Add a parameter for consuming runtime variable (-envs)
Sample command- client -buildpacks=true -type=http -builder-target=write_http_declarative_concurrent -builder-source tests/conformance -start-delay 1 -validate-concurrency=true -builder-runtime=python310 -builder-tag=python310_20220320_3_10_2_RC00 -envs web_concurrency_workers=4,web_concurrency_threads=3