### PR TITLE
Revert "feature: test 1000 concurrent requests at a time (#112)"

### DIFF
--- a/client/concurrency.go
+++ b/client/concurrency.go
@@ -164,7 +164,7 @@ func sendConcurrentRequests(sendFn func() error) error {
 	// the requests were handled serially, using the single request time
 	// as a benchmark. The concurrent time should be less than half of the
 	// time it would have taken to execute all requests serially.
-	if conReqTime*2 > numConReqs*singleReqTime {
+	if conReqTime > 2*singleReqTime {
 		return fmt.Errorf("function took too long to complete %d concurrent requests. %d concurrent request time: %s, single request time: %s", numConReqs, numConReqs, conReqTime, singleReqTime)
 	}
 	log.Printf("Concurrent request response time benchmarked, took %s for %d requests", conReqTime, numConReqs)

--- a/client/concurrency.go
+++ b/client/concurrency.go
@@ -162,8 +162,7 @@ func sendConcurrentRequests(sendFn func() error) error {
 
 	// Validate that the concurrent requests were handled faster than if all
 	// the requests were handled serially, using the single request time
-	// as a benchmark. The concurrent time should be less than half of the
-	// time it would have taken to execute all requests serially.
+	// as a benchmark. Some buffer is provided by doubling the single request time.
 	if conReqTime > 2*singleReqTime {
 		return fmt.Errorf("function took too long to complete %d concurrent requests. %d concurrent request time: %s, single request time: %s", numConReqs, numConReqs, conReqTime, singleReqTime)
 	}


### PR DESCRIPTION
This reverts commit 4f37e559575e4770aad085cde8ac0b65b85e9036.

Setting the number of requests for concurrency tests back to 10.