### PR TITLE
feat: add 'cache-path' parameter to actions/client/install

### DIFF
--- a/.github/actions/client/install/action.yml
+++ b/.github/actions/client/install/action.yml
@@ -7,6 +7,9 @@ inputs:
   cache-key:
     description: 'Cache key for storing client'
     default: conformance-client-latest
+  cache-path:
+    description: 'Filepath where the client is installed'
+    default: ~/go/bin/client
 runs:
   using: "composite"
   steps:
@@ -17,8 +20,12 @@ runs:
     - name: Install client
       run: go install github.com/GoogleCloudPlatform/functions-framework-conformance/client@${{ inputs.client-version }}
       shell: bash
+    - name: Move client to cache-path
+      # 'mv' fails if the src and dest path are the same, so move it to a temp first just in case
+      run: mv ~/go/bin/client /tmp/client && mv /tmp/client ${{ inputs.cache-path }}
+      shell: bash
     - name: Cache client
       uses: actions/cache@v3
       with:
-        path: ~/go/bin/client
+        path: ${{ inputs.cache-path }}
         key: ${{ inputs.cache-key }}

--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -109,6 +109,7 @@ jobs:
         uses: ./.github/actions/client/install
         with:
           client-version: ${{ env.CLIENT_VERSION }}
+          cache-path: ~/go/bin/client
           cache-key: ${{ steps.set-cached-client-version.outputs.key }}
 
   run-buildpack-integration-test:


### PR DESCRIPTION
This makes the action more flexible so Action users can define their own destination path instead of needing to know that it will be installed at `~/go/bin/client`