### PR TITLE
feat: use gae-runtimes GCR for builders

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,5 +39,4 @@ jobs:
         -validate-mapping=false \
         -builder-source='testdata' \
         -builder-target='HTTP' \
-        -builder-runtime='go113' \
-        -builder-tag='go113_20220501_1_13_15_RC00'
+        -builder-runtime='go113'

--- a/client/buildpacks.go
+++ b/client/buildpacks.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	image             = "conformance-test-func"
-	builderURL        = "gcr.io/gae-runtimes/buildpacks/%s/builder:%s"
+	builderURL        = "gcr.io/buildpacks/builder:%s"
 	gcfTargetPlatform = "gcf"
 )
 
@@ -82,7 +82,7 @@ func (b *buildpacksFunctionServer) OutputFile() ([]byte, error) {
 }
 
 func (b *buildpacksFunctionServer) build(ctx context.Context) error {
-	builder := fmt.Sprintf(builderURL, b.runtime, b.tag)
+	builder := fmt.Sprintf(builderURL, b.tag)
 
 	cmd := exec.Command("docker", "pull", builder)
 	output, err := cmd.CombinedOutput()

--- a/client/buildpacks.go
+++ b/client/buildpacks.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	image             = "conformance-test-func"
-	builderURL        = "us.gcr.io/fn-img/buildpacks/%s/builder:%s"
+	builderURL        = "gcr.io/gae-runtimes/buildpacks/%s/builder:%s"
 	gcfTargetPlatform = "gcf"
 )
 


### PR DESCRIPTION
This includes the ability to use the latest tag to always test with the latest builder.