### PR TITLE
chore: buildpack integ tests upload logs from container

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -151,11 +151,18 @@ jobs:
         if: ${{ matrix.builder-source }}
         run: |
           client \
-          -type=${{ matrix.type }} \
-          -builder-source=${{ matrix.builder-source }} \
-          -builder-target=${{ matrix.builder-target }} \
-          -builder-runtime=${{ inputs.builder-runtime }} \
-          -builder-tag=${{ inputs.builder-tag }} \
-          -start-delay=${{ inputs.start-delay }} \
-          -output-file=${{ inputs.output-file }} \
-          -validate-mapping=false
+            -type=${{ matrix.type }} \
+            -builder-source=${{ matrix.builder-source }} \
+            -builder-target=${{ matrix.builder-target }} \
+            -builder-runtime=${{ inputs.builder-runtime }} \
+            -builder-tag=${{ inputs.builder-tag }} \
+            -start-delay=${{ inputs.start-delay }} \
+            -output-file=${{ inputs.output-file }} \
+            -validate-mapping=false
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ${{ matrix.type }}_buildpack_integ_logs
+          path: /tmp/ff_*
+          retention-days: 5

--- a/client/buildpacks.go
+++ b/client/buildpacks.go
@@ -144,13 +144,14 @@ func (b *buildpacksFunctionServer) run() (func(), error) {
 		if err := b.logs(); err != nil {
 			log.Fatalf("getting container logs: %v", err)
 		}
+		log.Printf("Wrote logs to %v and %v.", b.stdoutFile, b.stderrFile)
 		if err := cmd.Process.Kill(); err != nil {
 			log.Fatalf("failed to kill process: %v", err)
 		}
 		if err := b.killContainer(); err != nil {
 			log.Fatalf("failed to kill container: %v", err)
 		}
-		log.Printf("Framework server shut down. Wrote logs to %v and %v.", b.stdoutFile, b.stderrFile)
+		log.Print("Framework server shut down.")
 	}, nil
 }
 

--- a/client/start.go
+++ b/client/start.go
@@ -28,8 +28,8 @@ import (
 )
 
 var (
-	defaultStdoutFile = path.Join(os.TempDir(), "serverlog_stdout.txt")
-	defaultStderrFile = path.Join(os.TempDir(), "serverlog_stderr.txt")
+	defaultStdoutFile = path.Join(os.TempDir(), "/ff_serverlog_stdout.txt")
+	defaultStderrFile = path.Join(os.TempDir(), "/ff_serverlog_stderr.txt")
 )
 
 type functionServer interface {


### PR DESCRIPTION
Improves debugability of buildpack integration tests by capturing logs from inside the containers that run under this test and uploading those logs as test artifacts.