### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -104,7 +104,7 @@ jobs:
         run: echo CLIENT_VERSION=${{ steps.conformance-client-latest.outputs.version }} >> $GITHUB_ENV
       - name: Set cache key for client version
         id: set-cached-client-version
-        run: echo "::set-output name=key::conformance-client-${{ env.CLIENT_VERSION }}"
+        run: echo "key=conformance-client-${{ env.CLIENT_VERSION }}" >> "$GITHUB_OUTPUT"
 
       # INSTALL CONFORMANCE CLIENT
       - name: Check for cached conformance test client


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter