### PR TITLE
chore: Update go.mod to use 1.21.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/functions-framework-conformance
 
-go 1.21
+go 1.21.13
 
 require (
 	github.com/buildpacks/pack v0.30.0


### PR DESCRIPTION
This should fix the "Invalid Go toolchain version" message in the Security page